### PR TITLE
Fix str() function

### DIFF
--- a/c/vm.c
+++ b/c/vm.c
@@ -968,7 +968,7 @@ static Value strNative(int argCount, Value *args) {
     char *numberString = malloc(sizeof(char) * numberStringLength);
     snprintf(numberString, numberStringLength, "%.15g", number);
 
-    ObjString *string = copyString(numberString, numberStringLength);
+    ObjString *string = copyString(numberString, numberStringLength - 1);
     free(numberString);
 
     return OBJ_VAL(string);


### PR DESCRIPTION
# Fix str() function

Resolves #7 

Currently within the str() function the length of the string is calculated via `snprintf`, and one is added to the length, this however causes an issue as the `copyString` function is not expecting this extra character therefore creating a string which is perceived as different.