### PR TITLE
Fixed implicit fallthrough in switch case

### DIFF
--- a/c/scanner.c
+++ b/c/scanner.c
@@ -164,6 +164,7 @@ static TokenType identifierType() {
                         return checkKeyword(2, 4, "port", TOKEN_IMPORT);
                 }
             }
+            break;
         case 'n':
             return checkKeyword(1, 2, "il", TOKEN_NIL);
         case 'o':
@@ -179,6 +180,7 @@ static TokenType identifierType() {
                         return checkKeyword(2, 4, "atic", TOKEN_STATIC);
                 }
             }
+            break;
         case 't':
             if (scanner.current - scanner.start > 1) {
                 switch (scanner.start[1]) {


### PR DESCRIPTION
Fixed implicit fall-through in switch..case. This doesn't fix a bug, but makes it possible to compile with `-Werror`