### PR TITLE
Comparisons between dicts and lists

### DIFF
--- a/c/memory.c
+++ b/c/memory.c
@@ -267,6 +267,7 @@ void collectGarbage() {
     grayTable(&vm.globals);
     grayCompilerRoots();
     grayObject((Obj *) vm.initString);
+    grayObject((Obj *) vm.replVar);
 
     // Traverse the references.
     while (vm.grayCount > 0) {

--- a/c/value.c
+++ b/c/value.c
@@ -191,8 +191,67 @@ void printValue(Value value) {
 #endif
 }
 
+static bool dictComparison(Value a, Value b) {
+    ObjDict *dict = AS_DICT(a);
+    ObjDict *dictB = AS_DICT(b);
+
+    // Different lengths, not the same
+    if (dict->capacity != dictB->capacity)
+        return false;
+
+    // Lengths are the same, and dict 1 has 0 length
+    // therefore both are empty
+    if (dict->count == 0) {
+        printf("here\n");
+        return true;
+    }
+
+    for (int i = 0; i < dict->capacity; ++i) {
+        dictItem *item = dict->items[i];
+        dictItem *itemB = dictB->items[i];
+
+        if (!item || !itemB) {
+            continue;
+        }
+
+        if (strcmp(item->key, itemB->key) != 0)
+            return false;
+
+        if (!valuesEqual(item->item, itemB->item))
+            return false;
+    }
+
+    return true;
+}
+
+static bool listComparison(Value a, Value b) {
+    ObjList *list = AS_LIST(a);
+    ObjList *listB = AS_LIST(b);
+
+    if (list->values.count != listB->values.count)
+        return false;
+
+    for (int i = 0; i < list->values.count; ++i) {
+        if (!valuesEqual(list->values.values[i], listB->values.values[i]))
+            return false;
+    }
+
+    return true;
+}
+
 bool valuesEqual(Value a, Value b) {
 #ifdef NAN_TAGGING
+
+    if (IS_OBJ(a) && IS_OBJ(b)) {
+        if (AS_OBJ(a)->type == OBJ_DICT && AS_OBJ(b)->type == OBJ_DICT) {
+            return dictComparison(a, b);
+        }
+
+        if (AS_OBJ(a)->type == OBJ_LIST && AS_OBJ(b)->type == OBJ_LIST) {
+            return listComparison(a, b);
+        }
+    }
+
     return a == b;
 #else
     if (a.type != b.type) return false;

--- a/c/value.c
+++ b/c/value.c
@@ -201,10 +201,8 @@ static bool dictComparison(Value a, Value b) {
 
     // Lengths are the same, and dict 1 has 0 length
     // therefore both are empty
-    if (dict->count == 0) {
-        printf("here\n");
+    if (dict->count == 0)
         return true;
-    }
 
     for (int i = 0; i < dict->capacity; ++i) {
         dictItem *item = dict->items[i];

--- a/c/vm.c
+++ b/c/vm.c
@@ -89,6 +89,7 @@ void initVM(bool repl) {
     initTable(&vm.globals);
     initTable(&vm.strings);
     vm.initString = copyString("init", 4);
+    vm.replVar = copyString("_", 1);
     defineAllNatives();
 }
 
@@ -96,6 +97,7 @@ void freeVM() {
     freeTable(&vm.globals);
     freeTable(&vm.strings);
     vm.initString = NULL;
+    vm.replVar = NULL;
     freeObjects();
     freeLists();
 }
@@ -369,8 +371,7 @@ static void concatenate() {
 }
 
 static void setReplVar(Value value) {
-    ObjString *replVariable = copyString("_", 1);
-    tableSet(&vm.globals, replVariable, value);
+    tableSet(&vm.globals, vm.replVar, value);
 }
 
 static InterpretResult run() {

--- a/c/vm.h
+++ b/c/vm.h
@@ -25,6 +25,7 @@ typedef struct {
     Table globals;
     Table strings;
     ObjString *initString;
+    ObjString *replVar;
     ObjUpvalue *openUpvalues;
     size_t bytesAllocated;
     size_t nextGC;


### PR DESCRIPTION
# Ability to compare lists and dictionaries.

Resolves #17 

This PR grants the ability to directly compare lists with lists, and dictionaries with dictionaries with the standard `==` operation.
e.g
```
[] == []; // true
["test", 1, nil] == ["test", 1, nil]; // true
[] == [nil]; // false
{"hello": 10} == {"hello": 10}; // true
{"hi": 2} == {"hi": 10} // false
```

This PR also fixes an issue with the repl variable.