### PR TITLE
Implement string methods

### DIFF
--- a/c/collections.c
+++ b/c/collections.c
@@ -119,7 +119,7 @@ static bool popListItem(int argCount) {
 
 static bool containsListItem(int argCount) {
     if (argCount != 2) {
-        runtimeError("contains() contains takes 2 arguments (%d  given)", argCount);
+        runtimeError("contains() takes 2 arguments (%d  given)", argCount);
         return false;
     }
 

--- a/c/collections.c
+++ b/c/collections.c
@@ -4,7 +4,7 @@
 
 static bool pushListItem(int argCount) {
     if (argCount != 2) {
-        runtimeError("push() takes two arguments (%d given)", argCount);
+        runtimeError("push() takes 2 arguments (%d given)", argCount);
         return false;
     }
 
@@ -19,7 +19,7 @@ static bool pushListItem(int argCount) {
 
 static bool insertListItem(int argCount) {
     if (argCount != 3) {
-        runtimeError("insert() takes three arguments (%d given)", argCount);
+        runtimeError("insert() takes 3 arguments (%d given)", argCount);
         return false;
     }
 
@@ -59,7 +59,7 @@ static bool insertListItem(int argCount) {
 
 static bool popListItem(int argCount) {
     if (argCount < 1 || argCount > 2) {
-        runtimeError("pop() takes either one or two arguments (%d  given)", argCount);
+        runtimeError("pop() takes either 1 or 2 arguments (%d  given)", argCount);
         return false;
     }
 
@@ -157,7 +157,7 @@ bool listMethods(char *method, int argCount) {
 
 static bool getDictItem(int argCount) {
     if (argCount != 3) {
-        runtimeError("get() takes three arguments (%d  given)", argCount);
+        runtimeError("get() takes 3 arguments (%d  given)", argCount);
         return false;
     }
 
@@ -184,7 +184,7 @@ static bool getDictItem(int argCount) {
 
 static bool removeDictItem(int argCount) {
     if (argCount != 2) {
-        runtimeError("remove() takes two arguments (%d  given)", argCount);
+        runtimeError("remove() takes 2 arguments (%d  given)", argCount);
         return false;
     }
 
@@ -215,7 +215,7 @@ static bool removeDictItem(int argCount) {
 
 static bool dictItemExists(int argCount) {
     if (argCount != 2) {
-        runtimeError("exists() takes two arguments (%d  given)", argCount);
+        runtimeError("exists() takes 2 arguments (%d  given)", argCount);
         return false;
     }
 

--- a/c/object.c
+++ b/c/object.c
@@ -212,7 +212,7 @@ void printObject(Value value) {
             break;
 
         case OBJ_STRING:
-            printf("%s", AS_CSTRING(value));
+            printf("'%s'", AS_CSTRING(value));
             break;
 
         case OBJ_LIST: {

--- a/c/strings.c
+++ b/c/strings.c
@@ -1,0 +1,68 @@
+#include "strings.h"
+#include "vm.h"
+#include "memory.h"
+
+static bool splitString(int argCount) {
+    if (argCount != 2) {
+        runtimeError("split() takes 2 arguments (%d  given)", argCount);
+        return false;
+    }
+
+    if (!IS_STRING(peek(0))) {
+        runtimeError("Argument passed to split() must be a string");
+        return false;
+    }
+
+    char *delimiter = AS_CSTRING(pop());
+    char *string = AS_CSTRING(pop());
+    char *token;
+
+    ObjList *list = initList();
+
+    do {
+        token = strstr(string, delimiter);
+        if (token)
+            *token = '\0';
+
+        writeValueArray(&list->values, OBJ_VAL(copyString(string, strlen(string))));
+        string = token + strlen(delimiter);
+    } while(token != NULL);
+
+    push(OBJ_VAL(list));
+
+    return true;
+}
+
+static bool containsString(int argCount) {
+    if (argCount != 2) {
+        runtimeError("contains() takes 2 arguments (%d  given)", argCount);
+        return false;
+    }
+
+    if (!IS_STRING(peek(0))) {
+        runtimeError("Argument passed to contains() must be a string");
+        return false;
+    }
+
+    char *delimiter = AS_CSTRING(pop());
+    char *string = AS_CSTRING(pop());
+
+    if (!strstr(string, delimiter)) {
+        push(FALSE_VAL);
+        return true;
+    }
+
+    push(TRUE_VAL);
+    return true;
+}
+
+bool stringMethods(char *method, int argCount) {
+    if (strcmp(method, "split") == 0) {
+        return splitString(argCount);
+    } else if (strcmp(method, "contains") == 0) {
+        return containsString(argCount);
+    }
+
+    runtimeError("String has no method %s()", method);
+    return false;
+}

--- a/c/strings.c
+++ b/c/strings.c
@@ -56,12 +56,57 @@ static bool containsString(int argCount) {
     return true;
 }
 
+bool static findString(int argCount) {
+    if (argCount < 2 || argCount > 3) {
+        runtimeError("find() takes either 2 or 3 arguments (%d  given)", argCount);
+        return false;
+    }
+
+    int index = 1;
+
+    if (argCount == 3) {
+        if (!IS_NUMBER(peek(0))) {
+            runtimeError("Index passed to find() must be a number");
+            return false;
+        }
+
+        index = AS_NUMBER(pop());
+    }
+
+    if (!IS_STRING(peek(0))) {
+        runtimeError("Substring passed to find() must be a string");
+        return false;
+    }
+
+    char *substr = AS_CSTRING(pop());
+    char *string = AS_CSTRING(pop());
+
+    int position = 0;
+
+    for (int i = 0; i < index; ++i) {
+        char *result = strstr(string, substr);
+        if (!result) {
+            position = -1;
+            break;
+        }
+
+        position += (result - string) + (i * strlen(substr));
+        string = result + strlen(substr);
+    }
+
+    push(NUMBER_VAL(position));
+    return true;
+}
+
 bool stringMethods(char *method, int argCount) {
     if (strcmp(method, "split") == 0) {
         return splitString(argCount);
     } else if (strcmp(method, "contains") == 0) {
         return containsString(argCount);
+    } else if (strcmp(method, "find") == 0) {
+        return findString(argCount);
     }
+
 
     runtimeError("String has no method %s()", method);
     return false;

--- a/c/strings.c
+++ b/c/strings.c
@@ -105,12 +105,12 @@ static bool replaceString(int argCount) {
     }
 
     if (!IS_STRING(peek(0))) {
-        runtimeError("Argument passed to find() must be a string");
+        runtimeError("Argument passed to replace() must be a string");
         return false;
     }
 
     if (!IS_STRING(peek(1))) {
-        runtimeError("Argument passed to find() must be a string");
+        runtimeError("Argument passed to replace() must be a string");
         return false;
     }
 

--- a/c/strings.c
+++ b/c/strings.c
@@ -236,6 +236,67 @@ bool static endsWithString(int argCount) {
     return true;
 }
 
+static bool leftStripString(int argCount) {
+    if (argCount != 1) {
+        runtimeError("leftStrip() takes 1 argument (%d  given)", argCount);
+        return false;
+    }
+    ObjString *string = AS_STRING(pop());
+
+    bool charSeen = false;
+    int i, count = 0;
+
+    char *temp = malloc(sizeof(char) * (string->length + 1));
+
+    for (i = 0; i < string->length; ++i) {
+        if (!charSeen && isspace(string->chars[i])) {
+            count++;
+            continue;
+        }
+        temp[i - count] = string->chars[i];
+        charSeen = true;
+    }
+    temp[i - count] = '\0';
+    push(OBJ_VAL(copyString(temp, strlen(temp))));
+    free(temp);
+    return true;
+}
+
+static bool rightStripString(int argCount) {
+    if (argCount != 1) {
+        runtimeError("rightStrip() takes 1 argument (%d  given)", argCount);
+        return false;
+    }
+    ObjString *string = AS_STRING(pop());
+
+    int length;
+
+    char *temp = malloc(sizeof(char) * (string->length + 1));
+
+    for (length = string->length - 1; length > 0; --length) {
+        if (!isspace(string->chars[length])) {
+            break;
+        }
+    }
+
+    strncpy(temp, string->chars, length + 1);
+    temp[length + 1] = '\0';
+    push(OBJ_VAL(copyString(temp, strlen(temp))));
+    free(temp);
+    return true;
+}
+
+static bool stripString(int argCount) {
+    if (argCount != 1) {
+        runtimeError("strip() takes 1 argument (%d  given)", argCount);
+        return false;
+    }
+
+    leftStripString(1);
+    rightStripString(1);
+    return true;
+}
+
 bool stringMethods(char *method, int argCount) {
     if (strcmp(method, "split") == 0) {
         return splitString(argCount);
@@ -253,6 +314,12 @@ bool stringMethods(char *method, int argCount) {
         return startsWithString(argCount);
     } else if (strcmp(method, "endsWith") == 0) {
         return endsWithString(argCount);
+    } else if (strcmp(method, "leftStrip") == 0) {
+        return leftStripString(argCount);
+    } else if (strcmp(method, "rightStrip") == 0) {
+        return rightStripString(argCount);
+    } else if (strcmp(method, "strip") == 0) {
+        return stripString(argCount);
     }
 
     runtimeError("String has no method %s()", method);

--- a/c/strings.h
+++ b/c/strings.h
@@ -1,0 +1,9 @@
+#ifndef dictu_strings_h
+#define dictu_strings_h
+
+#include <stdbool.h>
+#include <string.h>
+
+bool stringMethods(char *method, int argCount);
+
+#endif //dictu_strings_h

--- a/c/strings.h
+++ b/c/strings.h
@@ -2,7 +2,9 @@
 #define dictu_strings_h
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 bool stringMethods(char *method, int argCount);
 

--- a/c/vm.c
+++ b/c/vm.c
@@ -21,6 +21,7 @@
 #include "vm.h"
 #include "util.h"
 #include "collections.h"
+#include "strings.h"
 
 VM vm; // [one]
 
@@ -238,6 +239,8 @@ static bool invoke(ObjString *name, int argCount) {
         return listMethods(name->chars, argCount + 1);
     } else if (IS_DICT(receiver)) {
         return dictMethods(name->chars, argCount + 1);
+    } else if (IS_STRING(receiver)) {
+        return stringMethods(name->chars, argCount + 1);
     }
 
     if (!IS_INSTANCE(receiver)) {

--- a/c/vm.c
+++ b/c/vm.c
@@ -1031,7 +1031,7 @@ static Value clockNative(int argCount, Value *args) {
 
 static Value numberNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("number() takes exactly one argument (%d given).", argCount);
+        runtimeError("number() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1048,7 +1048,7 @@ static Value numberNative(int argCount, Value *args) {
 
 static Value strNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("str() takes exactly one argument (%d given).", argCount);
+        runtimeError("str() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1071,7 +1071,7 @@ static Value strNative(int argCount, Value *args) {
 
 static Value typeNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("type() takes exactly one argument (%d given).", argCount);
+        runtimeError("type() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1100,7 +1100,7 @@ static Value typeNative(int argCount, Value *args) {
 
 static Value lenNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("len() takes exactly one argument (%d given).", argCount);
+        runtimeError("len() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1224,7 +1224,7 @@ static Value averageNative(int argCount, Value *args) {
 
 static Value floorNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("floor() takes exactly one argument (%d given).", argCount);
+        runtimeError("floor() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1234,7 +1234,7 @@ static Value floorNative(int argCount, Value *args) {
 
 static Value roundNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("round() takes exactly one argument (%d given).", argCount);
+        runtimeError("round() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1244,7 +1244,7 @@ static Value roundNative(int argCount, Value *args) {
 
 static Value ceilNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("ceil() takes exactly one argument (%d given).", argCount);
+        runtimeError("ceil() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1254,7 +1254,7 @@ static Value ceilNative(int argCount, Value *args) {
 
 static Value absNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("abs() takes exactly one argument (%d given).", argCount);
+        runtimeError("abs() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1268,7 +1268,7 @@ static Value absNative(int argCount, Value *args) {
 
 static Value boolNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("bool() takes exactly one argument (%d given).", argCount);
+        runtimeError("bool() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1278,7 +1278,7 @@ static Value boolNative(int argCount, Value *args) {
 
 static Value inputNative(int argCount, Value *args) {
     if (argCount > 1) {
-        runtimeError("input() takes at most one argument (%d given).", argCount);
+        runtimeError("input() takes exactly 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -1327,7 +1327,7 @@ static Value inputNative(int argCount, Value *args) {
 
 static void sleepNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("sleep() takes exactly one argument (%d  given)", argCount);
+        runtimeError("sleep() takes exactly 1 argument (%d  given)", argCount);
         return;
     }
 

--- a/docs/docs/built-ins.md
+++ b/docs/docs/built-ins.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Built in functions
-nav_order: 8
+nav_order: 9
 ---
 
 # Built in functions

--- a/docs/docs/classes.md
+++ b/docs/docs/classes.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Classes
-nav_order: 7
+nav_order: 8
 ---
 
 # Classes

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: Collections
-nav_order: 4
+nav_order: 5
 ---
 
-# Variables
+# Collections
 {: .no_toc }
 
 ## Table of contents

--- a/docs/docs/control-flow.md
+++ b/docs/docs/control-flow.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Control Flow
-nav_order: 6
+nav_order: 7
 ---
 
 # Control Flow

--- a/docs/docs/operators.md
+++ b/docs/docs/operators.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Operators
-nav_order: 5
+nav_order: 6
 ---
 
 # Operators

--- a/docs/docs/strings.md
+++ b/docs/docs/strings.md
@@ -1,0 +1,113 @@
+---
+layout: default
+title: Strings
+nav_order: 4
+---
+
+# Strings
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+## Strings
+Strings in Dictu are an immutable data type, this means, once a string has been created there is no way to modify a string directly, and instead a new string is created. Strings are created by having some sort of text between quotes, `"hello"` or `'hello'` is fine in Dictu.
+
+### .lower()
+
+To make all characters within a string lowercase, use the `.lower()` method.
+
+```py
+"DICTU".lower(); // dictu
+"DiCtU".lower(); // dictu
+```
+
+### .upper()
+
+To make all characters within a string uppercase, use the `.upper()` method.
+
+```py
+"dictu".lower(); // DICTU
+"DiCtU".lower(); // DICTU
+```
+
+### .startsWith(string)
+
+To check if a string starts with a certain substring, use the `.startsWith()` method.
+
+```py
+"dictu".startsWith("d"); // true
+"dictu".startsWith("u"); // false
+```
+
+### .endsWith(string)
+
+To check if a string ends with a certain substring, use the `.endsWith()` method.
+
+```py
+"dictu".endsWith("d"); // false
+"dictu".startsWith("u"); // true
+```
+
+### .split(delimiter)
+
+To split a string up into a list by a certain character or string, use the `.split()` method.
+
+```py
+"Dictu is great".split(" "); // ['Dictu', 'is', 'great']
+```
+
+### .replace(old, new)
+
+To replace a substring within a string, use the `.replace()` method.
+
+```py
+"Dictu is okay".replace("okay", "great"); // "Dictu is great"
+```
+
+### .contains(string)
+
+To check if a string contains another string, use the `.contains()` method.
+
+```py
+"Dictu is great".contains("Dictu"); // true
+```
+
+### .find(string, skip: optional)
+
+To find the index of a given string, use the `.find()` method.
+
+Skip is an optional parameter which can be passed to skip the first `n` amount of appearances of the given substring.
+
+```py
+"Hello, how are you?".find("how"); // 7
+"hello something hello".find("hello", 2); // 16 -- Skipped the first occurance of the word "hello"
+```
+
+### .leftStrip(string)
+
+To strip all whitespace at the beginning of a string, use the `.leftStrip()` method.
+
+```py
+"   hello".leftStrip(); // "hello"
+```
+
+### .rightStrip(string)
+
+To strip all whitespace at the end of a string, use the `.rightStrip()` method.
+
+```py
+"hello   ".rightStrip(); // "hello"
+```
+
+### .strip(string)
+
+To strip whitespace at the beginning and end of a string, use the `.strip()` method.
+
+```py
+"    hello    ".strip(); // "hello"
+```

--- a/docs/docs/strings.md
+++ b/docs/docs/strings.md
@@ -17,6 +17,14 @@ nav_order: 4
 ## Strings
 Strings in Dictu are an immutable data type, this means, once a string has been created there is no way to modify a string directly, and instead a new string is created. Strings are created by having some sort of text between quotes, `"hello"` or `'hello'` is fine in Dictu.
 
+### Concatenation
+
+To join strings together use the `+` operator.
+
+```py
+"hello " + "there!"; // "hello there!"
+```
+
 ### .lower()
 
 To make all characters within a string lowercase, use the `.lower()` method.


### PR DESCRIPTION
# String methods

Resolves #6 

Currently, there are no methods which allow you to manipulate strings in Dictu. This PR changes this by adding 11 methods which allow basic string functionality.

```
.lower()
.upper()
.startsWith()
.endsWith()
.split()
.replace()
.contains()
.find()
.leftStrip()
.rightStrip()
.strip()
```
Information about each method is included in the Docs.