### PR TITLE
Call resetStack on a runtime error

### DIFF
--- a/c/vm.c
+++ b/c/vm.c
@@ -58,6 +58,8 @@ void runtimeError(const char *format, ...) {
         fputs("\n", stderr);
         va_end(args);
     }
+
+    resetStack();
 }
 
 


### PR DESCRIPTION
# Fix runtimeError issues

Resolves #21 

Currently when a runtime error is thrown the stack is not being reset, this is causing errors to stack up and duplicate (see #21). This PR fixes this issue by resetting the stack when a runtime error takes place.