### PR TITLE
Implement the ability to copy mutable datatypes

### DIFF
--- a/c/collections.c
+++ b/c/collections.c
@@ -140,6 +140,25 @@ static bool containsListItem(int argCount) {
     return true;
 }
 
+static bool copyList(int argCount) {
+    if (argCount != 1) {
+        runtimeError("copy() takes 1 argument (%d  given)", argCount);
+        return false;
+    }
+
+    ObjList *oldList = AS_LIST(pop());
+    ObjList *newList = initList();
+
+    for (int i = 0; i < oldList->values.count; ++i) {
+        Value val = oldList->values.values[i];
+        writeValueArray(&newList->values, val);
+    }
+
+    push(OBJ_VAL(newList));
+
+    return true;
+}
+
 bool listMethods(char *method, int argCount) {
     if (strcmp(method, "push") == 0) {
         return pushListItem(argCount);
@@ -149,6 +168,8 @@ bool listMethods(char *method, int argCount) {
         return popListItem(argCount);
     } else if (strcmp(method, "contains") == 0) {
         return containsListItem(argCount);
+    } else if (strcmp(method, "copy") == 0) {
+        return copyList(argCount);
     }
 
     runtimeError("List has no method %s()", method);
@@ -241,6 +262,28 @@ static bool dictItemExists(int argCount) {
     return true;
 }
 
+static bool copyDict(int argCount) {
+    if (argCount != 1) {
+        runtimeError("copy() takes 1 argument (%d  given)", argCount);
+        return false;
+    }
+
+    ObjDict *oldDict = AS_DICT(pop());
+    ObjDict *newDict = initDict();
+
+    for (int i = 0; i < oldDict->capacity; ++i) {
+        if (oldDict->items[i] == NULL) {
+            continue;
+        }
+
+        insertDict(newDict, oldDict->items[i]->key, oldDict->items[i]->item);
+    }
+
+    push(OBJ_VAL(newDict));
+
+    return true;
+}
+
 bool dictMethods(char *method, int argCount) {
     if (strcmp(method, "get") == 0) {
         return getDictItem(argCount);
@@ -248,6 +291,8 @@ bool dictMethods(char *method, int argCount) {
         return removeDictItem(argCount);
     } else if (strcmp(method, "exists") == 0) {
         return dictItemExists(argCount);
+    } else if (strcmp(method, "copy") == 0) {
+        return copyDict(argCount);
     }
 
     runtimeError("Dict has no method %s()", method);

--- a/c/collections.c
+++ b/c/collections.c
@@ -114,7 +114,6 @@ static bool popListItem(int argCount) {
         }
     }
     list->values.count--;
-
     push(last);
 
     return true;
@@ -170,7 +169,6 @@ static bool copyListShallow(int argCount) {
     }
 
     ObjList *oldList = AS_LIST(pop());
-
     push(OBJ_VAL(copyList(oldList, true)));
 
     return true;
@@ -184,7 +182,6 @@ static bool copyListDeep(int argCount) {
     }
 
     ObjList *oldList = AS_LIST(pop());
-
     push(OBJ_VAL(copyList(oldList, false)));
 
     return true;

--- a/c/value.c
+++ b/c/value.c
@@ -116,6 +116,7 @@ void insertDict(ObjDict *dict, char *key, Value value) {
     if (dict->items[index]) {
         free(dict->items[index]->key);
         free(dict->items[index]);
+        dict->count--;
     }
 
     dict->items[index] = item;

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -66,6 +66,38 @@ myList.pop(0); // 1
 myList; // [2]
 ```
 
+### Copying lists
+When you are working with a mutable datatype taking a reference of a list when creating a new variable will modify the original list.
+```js
+var list1 = [1, 2];
+var list2 = list1;
+list2[0] = 10;
+print(list1); // [10, 2]
+```
+To get around this we can make copies of the list. Dictu offers the ability to both shallow and deep copy a list.
+```js
+var list1 = [1, 2];
+var list2 = list1.copy(); // shallow copy
+list2[0] = 10;
+print(list1); // [1, 2]
+print(list2); // [10, 2]
+```
+This works fine, however if you have a mutable datatype within the array on a shallow copy, you're back to square one.
+```js
+var list1 = [[1, 2];
+var list2 = list1.copy();
+list2[0][0] = 10;
+print(list1); // [[10, 2]]
+```
+To get around this, we can deepCopy the list.
+```js
+var list1 = [[1, 2];
+var list2 = list1.deepCopy();
+list2[0][0] = 10;
+print(list1); // [[1, 2]]
+print(list2); // [[10, 2]]
+```
+
 ## Dictionaries
 
 Dictionaries are a key:value pair data type. Currently Dictu requires that the dictionary key be a string, however the value can be any type.
@@ -120,4 +152,14 @@ var myDict = {"key": 1, "key1": true};
 myDict.remove("key");
 myDict; // {'key1': true}
 myDict.remove("unknown key"); // [line 1] in script: Key 'unknown key' passed to remove() does not exist
+```
+
+### Copying dictionaries
+
+This is the exact same scenario as lists, so refer to [copying Lists](#copying-lists) for information as to what is happening.
+
+```js
+var myDict = {"key": {"test": 10}};
+var myDict1 = myDict.copy(); // Shallow copy
+var myDict2 = myDict.deepCopy(); // Deep copy
 ```

--- a/tests/dicts/copy.du
+++ b/tests/dicts/copy.du
@@ -1,0 +1,29 @@
+var myDict = {"key": 1, "key1": true};
+
+// First check the dictionary was created properly
+assert(myDict == {"key": 1, "key1": true});
+
+var myDictCopy = myDict.copy(); // shallow copy
+
+assert(myDictCopy == {"key": 1, "key1": true});
+
+myDictCopy["key"] = 10;
+
+assert(myDict == {"key": 1, "key1": true});
+assert(myDictCopy == {"key": 10, "key1": true});
+
+var newDict = {"key": [1, "hey"], "key1": {"test": 10}};
+var deepCopy = newDict.deepCopy();
+
+assert(newDict == {"key": [1, "hey"], "key1": {"test": 10}});
+assert(deepCopy == {"key": [1, "hey"], "key1": {"test": 10}});
+
+deepCopy["key"][1] = "test";
+
+assert(newDict == {"key": [1, "hey"], "key1": {"test": 10}});
+assert(deepCopy == {"key": [1, "test"], "key1": {"test": 10}});
+
+deepCopy["key1"]["test"] = 20;
+
+assert(newDict == {"key": [1, "hey"], "key1": {"test": 10}});
+assert(deepCopy == {"key": [1, "test"], "key1": {"test": 20}});

--- a/tests/dicts/import.du
+++ b/tests/dicts/import.du
@@ -1,3 +1,5 @@
 import "tests/dicts/subscript.du";
 import "tests/dicts/get.du";
 import "tests/dicts/exists.du";
+import "tests/dicts/remove.du";
+import "tests/dicts/copy.du";

--- a/tests/lists/copy.du
+++ b/tests/lists/copy.du
@@ -1,0 +1,24 @@
+var x = [1, 2, 3, 4, 5];
+
+// First check the list was created properly
+assert(x == [1, 2, 3, 4, 5]);
+
+var y = x.copy(); // shallow copy
+assert(y == [1, 2, 3, 4, 5]);
+
+y[0] = 10;
+
+assert(x == [1, 2, 3, 4, 5]);
+assert(y == [10, 2, 3, 4, 5]);
+
+var newList = [[1, "hello"], {"test": 10}];
+assert(newList == [[1, "hello"], {"test": 10}]);
+
+var deepCopy = newList.deepCopy();
+assert(deepCopy == [[1, "hello"], {"test": 10}]);
+
+deepCopy[0][0] = 10;
+deepCopy[1]["test"] = 11;
+
+assert(newList == [[1, "hello"], {"test": 10}]);
+assert(deepCopy == [[10, "hello"], {"test": 11}]);

--- a/tests/lists/import.du
+++ b/tests/lists/import.du
@@ -3,3 +3,4 @@ import "tests/lists/contains.du";
 import "tests/lists/push.du";
 import "tests/lists/insert.du";
 import "tests/lists/pop.du";
+import "tests/lists/copy.du";


### PR DESCRIPTION
Currently there is no way to make a copy of lists and dictionaries. Due to them being mutable taking a reference will mutate the original list. This PR changes this by implementing the ability to copy them.

```js
var x = [1, 2, [3, 4]];
var y = x.copy(); // Shallow copy
var z = x.deepCopy(); // Deep copy
```

```js
var x = {"key": {"key1": 10}};
var y = x.copy(); // Shallow copy
var z = x.deepCopy(); // Deep copy
```

Documentation has also been updated to explain the two new functions.
Tests created for copy() and deepCopy().