### PR TITLE
Feature/string format

### DIFF
--- a/c/object.c
+++ b/c/object.c
@@ -232,7 +232,7 @@ char *objectToString(Value value) {
         case OBJ_STRING: {
             ObjString *stringObj = AS_STRING(value);
             char *string = malloc(sizeof(char) * stringObj->length + 3);
-            snprintf(string, stringObj->length + 3, "'%s'", stringObj->chars);
+            snprintf(string, stringObj->length + 1, "%s", stringObj->chars);
             return string;
         }
 

--- a/c/strings.c
+++ b/c/strings.c
@@ -114,7 +114,7 @@ static bool findString(int argCount) {
 
 static bool replaceString(int argCount) {
     if (argCount != 3) {
-        runtimeError("replace() takes 3 arguments (%d  given)", argCount);
+        runtimeError("replace() takes 3 arguments (%d given)", argCount);
         return false;
     }
 
@@ -326,6 +326,67 @@ static bool stripString(int argCount) {
     return true;
 }
 
+static bool formatString(int argCount) {
+    if (argCount == 0) {
+        runtimeError("format() takes at least 1 argument (%d given)", argCount);
+        return false;
+    }
+
+    int length = 0;
+    char **replace_strings = malloc((argCount - 1) * sizeof(char*));
+
+    for (int j = 0; j < argCount - 1; ++j) {
+        replace_strings[j] = valueToString(pop());
+        length += strlen(replace_strings[j]);
+    }
+
+    char *string = AS_CSTRING(pop());
+
+    int count = 0;
+    const char *tmp = string;
+    while((tmp = strstr(tmp, "{}")))
+    {
+        count++;
+        tmp++;
+    }
+
+    if (count != argCount - 1) {
+        runtimeError("format() arguments does not match placeholders");
+        return false;
+    }
+
+    int fullLength = strlen(string) - count * 2 + length + 1;
+    char *pos;
+    const char *tmp1 = string;
+    char *newStr = malloc(sizeof(char) * fullLength);
+
+    for (int i = 0; i < argCount - 1; ++i) {
+        pos = strstr(tmp1, "{}");
+        if (pos != NULL)
+            *pos = '\0';
+
+        if (i == 0)
+            snprintf(newStr, fullLength, "%s", tmp1);
+        else
+            strncat(newStr, tmp1, strlen(tmp1));
+
+        strncat(newStr, replace_strings[i], strlen(replace_strings[i]));
+        tmp1 = pos + 2;
+
+        free(replace_strings[i]);
+    }
+
+    free(replace_strings);
+
+    strncat(newStr, tmp1, strlen(tmp1));
+    ObjString *newString = copyString(newStr, fullLength - 1);
+    push(OBJ_VAL(newString));
+
+    free(newStr);
+
+    return true;
+}
+
 bool stringMethods(char *method, int argCount) {
     if (strcmp(method, "split") == 0) {
         return splitString(argCount);
@@ -349,6 +410,8 @@ bool stringMethods(char *method, int argCount) {
         return rightStripString(argCount);
     } else if (strcmp(method, "strip") == 0) {
         return stripString(argCount);
+    } else if (strcmp(method, "format") == 0) {
+        return formatString(argCount);
     }
 
     runtimeError("String has no method %s()", method);

--- a/c/strings.c
+++ b/c/strings.c
@@ -352,6 +352,13 @@ static bool formatString(int argCount) {
 
     if (count != argCount - 1) {
         runtimeError("format() arguments does not match placeholders");
+
+        for (int i = 0; i < argCount - 1; ++i) {
+            free(replace_strings[i]);
+        }
+
+        free(replace_strings);
+
         return false;
     }
 

--- a/c/strings.c
+++ b/c/strings.c
@@ -335,23 +335,28 @@ static bool formatString(int argCount) {
     int length = 0;
     char **replace_strings = malloc((argCount - 1) * sizeof(char*));
 
-    for (int j = 0; j < argCount - 1; ++j) {
+    for (int j = argCount - 2; j >= 0; --j) {
         replace_strings[j] = valueToString(pop());
         length += strlen(replace_strings[j]);
     }
 
     char *string = AS_CSTRING(pop());
 
+    char *tmp = malloc(strlen(string) + 1);
+    char *tmpFree = tmp;
+    strcpy(tmp, string);
+
     int count = 0;
-    const char *tmp = string;
     while((tmp = strstr(tmp, "{}")))
     {
         count++;
         tmp++;
     }
 
+    free(tmpFree);
+
     if (count != argCount - 1) {
-        runtimeError("format() arguments does not match placeholders");
+        runtimeError("format() placeholders do not match arguments");
 
         for (int i = 0; i < argCount - 1; ++i) {
             free(replace_strings[i]);
@@ -364,7 +369,9 @@ static bool formatString(int argCount) {
 
     int fullLength = strlen(string) - count * 2 + length + 1;
     char *pos;
-    const char *tmp1 = string;
+    char *tmp1 = malloc(strlen(string) + 1);
+    char *tmp1Free = tmp1;
+    strcpy(tmp1, string);
     char *newStr = malloc(sizeof(char) * fullLength);
 
     for (int i = 0; i < argCount - 1; ++i) {
@@ -390,6 +397,7 @@ static bool formatString(int argCount) {
     push(OBJ_VAL(newString));
 
     free(newStr);
+    free(tmp1Free);
 
     return true;
 }

--- a/c/strings.c
+++ b/c/strings.c
@@ -327,8 +327,8 @@ static bool stripString(int argCount) {
 }
 
 static bool formatString(int argCount) {
-    if (argCount == 0) {
-        runtimeError("format() takes at least 1 argument (%d given)", argCount);
+    if (argCount == 1) {
+        runtimeError("format() takes at least 2 arguments (%d given)", argCount);
         return false;
     }
 

--- a/docs/docs/strings.md
+++ b/docs/docs/strings.md
@@ -119,3 +119,14 @@ To strip whitespace at the beginning and end of a string, use the `.strip()` met
 ```py
 "    hello    ".strip(); // "hello"
 ```
+
+### .format(...args...)
+
+To format a string with any type of value `.format()` can be used. This will convert any type
+to a string and swap placeholders `{}` for values.
+
+```py
+"Hello {}".format("Jason"); // "Hello Jason"
+
+"{} {} {} {}".format(10, "hi", [10, 20], {"test": 10}) // '10 hi [10, 20] {"test": 10}'
+```

--- a/tests/strings/format.du
+++ b/tests/strings/format.du
@@ -1,0 +1,5 @@
+assert("hello {}".format("jason") == "hello jason");
+assert("hello {}".format(10) == "hello 10");
+assert("hello {}".format([10]) == "hello [10]");
+assert("hello {}. {} {}".format("jason", 10, [10]) == "hello jason. 10 [10]");
+assert("{}".format("jason") == "jason");

--- a/tests/strings/import.du
+++ b/tests/strings/import.du
@@ -7,3 +7,4 @@ import "tests/strings/endsWith.du";
 import "tests/strings/find.du";
 import "tests/strings/contains.du";
 import "tests/strings/strip.du";
+import "tests/strings/format.du";


### PR DESCRIPTION
This PR introduces `.format()`. This works identical to python with a very slight difference. In Python, `.format()` allows there to be more arguments than placeholders, this however, is an error in Dictu.

Resolves #5 

Example:
```py
"Hello {}".format("Jason"); // Hello Jason
```