### PR TITLE
Update tests to include comment headers

### DIFF
--- a/c/collections.c
+++ b/c/collections.c
@@ -219,12 +219,15 @@ bool listMethods(char *method, int argCount) {
 }
 
 static bool getDictItem(int argCount) {
-    if (argCount != 3) {
-        runtimeError("get() takes 3 arguments (%d  given)", argCount);
+    if (argCount != 2 && argCount != 3) {
+        runtimeError("get() takes 2 or 3 arguments (%d  given)", argCount);
         return false;
     }
 
-    Value defaultValue = pop();
+    Value defaultValue = NIL_VAL;
+    if (argCount == 3) {
+        defaultValue = pop();
+    }
 
     if (!IS_STRING(peek(0))) {
         runtimeError("Key passed to get() must be a string");

--- a/c/files.c
+++ b/c/files.c
@@ -82,6 +82,8 @@ static bool readLineFile(int argCount) {
 
     ObjFile *file = AS_FILE(pop());
     if (fgets(line, 4096, file->file) != NULL) {
+        // Remove newline char
+        line[strcspn(line, "\n")] = '\0';
         push(OBJ_VAL(copyString(line, strlen(line))));
     } else {
         push(OBJ_VAL(copyString("", 0)));
@@ -90,7 +92,7 @@ static bool readLineFile(int argCount) {
 }
 
 static bool seekFile(int argCount) {
-    if (argCount < 2 || argCount > 3) {
+    if (argCount != 2 && argCount != 3) {
         runtimeError("seek() takes 2 or 3 arguments (%d given)", argCount);
         return false;
     }

--- a/c/natives.c
+++ b/c/natives.c
@@ -42,7 +42,7 @@ static Value clockNative(int argCount, Value *args) {
 
 static Value numberNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("number() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("number() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -59,7 +59,7 @@ static Value numberNative(int argCount, Value *args) {
 
 static Value strNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("str() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("str() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -77,7 +77,7 @@ static Value strNative(int argCount, Value *args) {
 
 static Value typeNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("type() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("type() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -117,7 +117,7 @@ static Value typeNative(int argCount, Value *args) {
 
 static Value lenNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("len() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("len() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -239,7 +239,7 @@ static Value averageNative(int argCount, Value *args) {
 
 static Value floorNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("floor() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("floor() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -254,7 +254,7 @@ static Value floorNative(int argCount, Value *args) {
 
 static Value roundNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("round() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("round() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -269,7 +269,7 @@ static Value roundNative(int argCount, Value *args) {
 
 static Value ceilNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("ceil() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("ceil() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -284,7 +284,7 @@ static Value ceilNative(int argCount, Value *args) {
 
 static Value absNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("abs() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("abs() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -303,7 +303,7 @@ static Value absNative(int argCount, Value *args) {
 
 static Value boolNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("bool() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("bool() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -313,7 +313,7 @@ static Value boolNative(int argCount, Value *args) {
 
 static Value inputNative(int argCount, Value *args) {
     if (argCount > 1) {
-        runtimeError("input() takes exactly 1 argument (%d given).", argCount);
+        runtimeError("input() takes 1 argument (%d given).", argCount);
         return NIL_VAL;
     }
 
@@ -362,7 +362,7 @@ static Value inputNative(int argCount, Value *args) {
 
 static bool sleepNative(int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError("sleep() takes exactly 1 argument (%d given)", argCount);
+        runtimeError("sleep() takes 1 argument (%d given)", argCount);
         return false;
     }
 

--- a/tests/builtins/import.du
+++ b/tests/builtins/import.du
@@ -1,3 +1,9 @@
+/**
+* import.du
+*
+* General import file for all the builtin function tests
+*/
+
 import "tests/builtins/str.du";
 import "tests/builtins/number.du";
 import "tests/builtins/type.du";

--- a/tests/builtins/len.du
+++ b/tests/builtins/len.du
@@ -1,3 +1,11 @@
+/**
+* len.du
+*
+* Testing the builtin len() function
+*
+* len() returns the length of a string or collection
+*/
+
 assert(len("123456789") == 9);
 assert(len([1, 2, 3, 4, 5]) == 5);
 assert(len([1, [2, 3], [4, 5, [6]]]) == 3);

--- a/tests/builtins/maths.du
+++ b/tests/builtins/maths.du
@@ -1,3 +1,11 @@
+/**
+* maths.du
+*
+* Testing the builtin maths functions:
+*    - min(), max(), average(), sum(), floor(), round(), ceil(), abs()
+*
+*/
+
 assert(min(1, 2, 3) == 1);
 assert(min([1, 2, 3]) == 1);
 assert(max(1, 2, 3) == 3);

--- a/tests/builtins/number.du
+++ b/tests/builtins/number.du
@@ -1,3 +1,11 @@
+/**
+* number.du
+*
+* Testing the builtin number() function
+*
+* number() converts a string to a number
+*/
+
 assert(number("10") == 10);
 assert(number("10.2") == 10.2);
 assert(number("10.123456") == 10.123456);

--- a/tests/builtins/sleep.du
+++ b/tests/builtins/sleep.du
@@ -1,3 +1,11 @@
+/**
+* sleep.du
+*
+* Testing the builtin sleep() function
+*
+* sleep() pauses execution for a given amount of seconds
+*/
+
 var start = time();
 
 sleep(2);

--- a/tests/builtins/str.du
+++ b/tests/builtins/str.du
@@ -1,3 +1,11 @@
+/**
+* str.du
+*
+* Testing the builtin str() function
+*
+* str() returns a value as a string
+*/
+
 assert(str(10) == "10");
 assert(str(10.2) == "10.2");
 assert(str("hello") == "hello");

--- a/tests/builtins/type.du
+++ b/tests/builtins/type.du
@@ -1,3 +1,11 @@
+/**
+* type.du
+*
+* Testing the builtin type() function
+*
+* type() returns the type of a value as a string
+*/
+
 assert(type(10) == "number");
 assert(type("test") == "string");
 assert(type([1, 2]) == "list");

--- a/tests/classes/import.du
+++ b/tests/classes/import.du
@@ -1,3 +1,9 @@
+/**
+* import.du
+*
+* General import file for all the class tests
+*/
+
 import "tests/classes/methodCall.du";
 import "tests/classes/static.du";
 import "tests/classes/properties.du";

--- a/tests/classes/inherit.du
+++ b/tests/classes/inherit.du
@@ -1,3 +1,9 @@
+/**
+* inherit.du
+*
+* Testing class inheritance
+*/
+
 class Base {
     func() {
         return 10;

--- a/tests/classes/methodCall.du
+++ b/tests/classes/methodCall.du
@@ -1,3 +1,9 @@
+/**
+* methodCall.du
+*
+* Testing class method calls
+*/
+
 class Test {
     func() {
         return 10;

--- a/tests/classes/properties.du
+++ b/tests/classes/properties.du
@@ -1,3 +1,9 @@
+/**
+* properties.du
+*
+* Testing class properties
+*/
+
 class Test {
     init() {
         this.x = 10;

--- a/tests/classes/static.du
+++ b/tests/classes/static.du
@@ -1,3 +1,9 @@
+/**
+* static.du
+*
+* Testing class static methods
+*/
+
 class Test {
     static func() {
         return 10;

--- a/tests/dicts/copy.du
+++ b/tests/dicts/copy.du
@@ -1,3 +1,12 @@
+/**
+* copy.du
+*
+* Testing the dict.copy() and dict.deepCopy() methods
+*
+* .copy() returns a shallow copy of the dictionary
+* .deepCopy() returns a deep copy of the dictionary
+*/
+
 var myDict = {"key": 1, "key1": true};
 
 // First check the dictionary was created properly

--- a/tests/dicts/exists.du
+++ b/tests/dicts/exists.du
@@ -1,3 +1,11 @@
+/**
+* exists.du
+*
+* Testing the dict.exists() method
+*
+* .exists() returns a boolean based on whether the given key exists
+*/
+
 var myDict = {"key": 1, "key1": true};
 
 // First check the dictionary was created properly

--- a/tests/dicts/get.du
+++ b/tests/dicts/get.du
@@ -1,10 +1,20 @@
+/**
+* get.du
+*
+* Testing the dict.exists() method
+*
+* .exists() returns a boolean based on whether the given key exists
+*/
+
 var myDict = {"key": 1, "key1": true};
 
 // First check the dictionary was created properly
 assert(myDict == {"key": 1, "key1": true});
 
-assert(myDict.get("key", nil) == 1);
-assert(myDict.get("key1", nil));
+assert(myDict.get("key") == 1);
+
+// Explicit compare to true to make the test more obvious
+assert(myDict.get("key1") == true);
 
 // Return a default value if key is not found
 assert(myDict.get("unknown", 10) == 10);

--- a/tests/dicts/import.du
+++ b/tests/dicts/import.du
@@ -1,3 +1,9 @@
+/**
+* import.du
+*
+* General import file for all the dictionary tests
+*/
+
 import "tests/dicts/subscript.du";
 import "tests/dicts/get.du";
 import "tests/dicts/exists.du";

--- a/tests/dicts/remove.du
+++ b/tests/dicts/remove.du
@@ -1,3 +1,11 @@
+/**
+* remove.du
+*
+* Testing the dict.remove() method
+*
+* .remove() mutates the dictionary to remove a key:value pair
+*/
+
 var myDict = {"key": 1, "key1": true};
 
 // First check the dictionary was created properly

--- a/tests/dicts/subscript.du
+++ b/tests/dicts/subscript.du
@@ -1,3 +1,9 @@
+/**
+* subscript.du
+*
+* Testing dictionary subscripts
+*/
+
 var myDict = {"key": 1, "key1": true};
 
 // First check the dictionary was created properly

--- a/tests/files/read.du
+++ b/tests/files/read.du
@@ -1,0 +1,6 @@
+with("tests/files/read.txt", "r") {
+    var line;
+     while (line = file.readLine()) {
+         assert(line == "Dictu is great!");
+     }
+ }

--- a/tests/files/read.txt
+++ b/tests/files/read.txt
@@ -1,0 +1,10 @@
+Dictu is great!
+Dictu is great!
+Dictu is great!
+Dictu is great!
+Dictu is great!
+Dictu is great!
+Dictu is great!
+Dictu is great!
+Dictu is great!
+Dictu is great!

--- a/tests/functions/import.du
+++ b/tests/functions/import.du
@@ -1,2 +1,8 @@
+/**
+* import.du
+*
+* General import file for all the function tests
+*/
+
 import "tests/functions/parameters.du";
 import "tests/functions/return.du";

--- a/tests/functions/parameters.du
+++ b/tests/functions/parameters.du
@@ -1,3 +1,9 @@
+/**
+* parameters.du
+*
+* Testing the parameters of a function
+*/
+
 def test(a) {
     assert(a == 10);
 }

--- a/tests/functions/return.du
+++ b/tests/functions/return.du
@@ -1,3 +1,9 @@
+/**
+* return.du
+*
+* Testing returning from a function
+*/
+
 def test() {
     return 10;
 }

--- a/tests/lists/contains.du
+++ b/tests/lists/contains.du
@@ -1,3 +1,11 @@
+/**
+* contains.du
+*
+* Testing the list.contains() method
+*
+* .contains() returns a boolean if the given value exists within the list
+*/
+
 var x = [1, 2, 3, 4, 5];
 
 // First check the list was created properly

--- a/tests/lists/copy.du
+++ b/tests/lists/copy.du
@@ -1,3 +1,12 @@
+/**
+* copy.du
+*
+* Testing the list.copy() and list.deepCopy() methods
+*
+* .copy() returns a shallow copy of the list
+* .deepCopy() returns a deep copy of the list
+*/
+
 var x = [1, 2, 3, 4, 5];
 
 // First check the list was created properly

--- a/tests/lists/import.du
+++ b/tests/lists/import.du
@@ -1,3 +1,9 @@
+/**
+* import.du
+*
+* General import file for all the function tests
+*/
+
 import "tests/lists/subscript.du";
 import "tests/lists/contains.du";
 import "tests/lists/push.du";

--- a/tests/lists/insert.du
+++ b/tests/lists/insert.du
@@ -1,3 +1,11 @@
+/**
+* insert.du
+*
+* Testing the list.insert() method
+*
+* .insert() will insert a new value into a list at a given index without replacing
+*/
+
 var x = [1, 2, 3, 4, 6];
 
 // First check the list was created properly

--- a/tests/lists/pop.du
+++ b/tests/lists/pop.du
@@ -1,3 +1,11 @@
+/**
+* pop.du
+*
+* Testing the list.pop() method
+*
+* .pop() will remove an element from a list and return the value
+*/
+
 var x = [1, 2, 3, 4, 5];
 
 // First check the list was created properly

--- a/tests/lists/push.du
+++ b/tests/lists/push.du
@@ -1,3 +1,11 @@
+/**
+* push.du
+*
+* Testing the list.push() method
+*
+* .push() will insert a new value at the end of a list
+*/
+
 var x = [1, 2, 3, 4, 5];
 
 // First check the list was created properly

--- a/tests/lists/subscript.du
+++ b/tests/lists/subscript.du
@@ -1,3 +1,9 @@
+/**
+* subscript.du
+*
+* Testing list subscripts
+*/
+
 var x = [1, 2, 3, 4, 5];
 
 // First check the list was created properly

--- a/tests/loops/continue.du
+++ b/tests/loops/continue.du
@@ -1,3 +1,9 @@
+/**
+* continue.du
+*
+* Testing continue in a loop
+*/
+
 var x = [];
 
 for (var i = 0; i < 10; ++i) {

--- a/tests/loops/import.du
+++ b/tests/loops/import.du
@@ -1,2 +1,8 @@
+/**
+* import.du
+*
+* General import file for all the loop tests
+*/
+
 import "tests/loops/loop.du";
 import "tests/loops/continue.du";

--- a/tests/loops/loop.du
+++ b/tests/loops/loop.du
@@ -1,3 +1,9 @@
+/**
+* loop.du
+*
+* Testing looping
+*/
+
 var x = [];
 
 for (var i = 0; i < 10; ++i) {

--- a/tests/operators/assignment.du
+++ b/tests/operators/assignment.du
@@ -1,3 +1,9 @@
+/**
+* assignment.du
+*
+* Testing variable assignment
+*/
+
 var x = 10;
 
 x += 10;

--- a/tests/operators/divide.du
+++ b/tests/operators/divide.du
@@ -1,3 +1,9 @@
+/**
+* divide.du
+*
+* Testing division
+*/
+
 var x = 10;
 
 assert(x / 10 == 1);

--- a/tests/operators/import.du
+++ b/tests/operators/import.du
@@ -1,3 +1,9 @@
+/**
+* import.du
+*
+* General import file for all the operator tests
+*/
+
 import "tests/operators/plus.du";
 import "tests/operators/subtract.du";
 import "tests/operators/multiply.du";

--- a/tests/operators/modulo.du
+++ b/tests/operators/modulo.du
@@ -1,3 +1,9 @@
+/**
+* modulo.du
+*
+* Testing modulo
+*/
+
 var x = 10;
 
 assert(x % 2 == 0);

--- a/tests/operators/multiply.du
+++ b/tests/operators/multiply.du
@@ -1,3 +1,9 @@
+/**
+* multiply.du
+*
+* Testing multiplication
+*/
+
 var x = 10;
 
 assert(x * 10 == 100);

--- a/tests/operators/plus.du
+++ b/tests/operators/plus.du
@@ -1,3 +1,9 @@
+/**
+* plus.du
+*
+* Testing addition
+*/
+
 var x = 10;
 
 assert(x + 1 == 11);

--- a/tests/operators/precedence.du
+++ b/tests/operators/precedence.du
@@ -1,3 +1,9 @@
+/**
+* precedence.du
+*
+* Testing operator precedence
+*/
+
 var x = 10;
 
 assert(x + 1 * 10 / 2 == 15);

--- a/tests/operators/prefix.du
+++ b/tests/operators/prefix.du
@@ -1,3 +1,9 @@
+/**
+* prefix.du
+*
+* Testing prefix operators
+*/
+
 var x = 10;
 
 assert(++x == 11);

--- a/tests/operators/subtract.du
+++ b/tests/operators/subtract.du
@@ -1,3 +1,9 @@
+/**
+* subtract.du
+*
+* Testing subtraction
+*/
+
 var x = 10;
 
 assert(x - 1 == 9);

--- a/tests/strings/concat.du
+++ b/tests/strings/concat.du
@@ -1,1 +1,7 @@
+/**
+* concat.du
+*
+* Testing string concatenation
+*/
+
 assert("Dictu" + " is " + "great!" == "Dictu is great!");

--- a/tests/strings/contains.du
+++ b/tests/strings/contains.du
@@ -1,2 +1,10 @@
+/**
+* contains.du
+*
+* Testing the str.contains() method
+*
+* .contains() returns a boolean depending on whether a substring exists
+*/
+
 assert("Dictu is great!".contains("is"));
 assert(!("Dictu is great!".contains("test")));

--- a/tests/strings/endsWith.du
+++ b/tests/strings/endsWith.du
@@ -1,3 +1,11 @@
+/**
+* endsWith.du
+*
+* Testing the str.endsWith() method
+*
+* .endsWith() returns a boolean based on whether the string ends with a given substring
+*/
+
 assert("test".endsWith("t"));
 assert("test".endsWith("st"));
 assert("test".endsWith("test"));

--- a/tests/strings/find.du
+++ b/tests/strings/find.du
@@ -1,6 +1,30 @@
+/**
+* find.du
+*
+* Testing the str.find() method
+*
+* .find() returns the index of a substring or -1 if not found
+*/
+
+// Exists
 assert("hello".find("hello") == 0);
 assert("hello".find("l") == 2);
 assert("hello".find("l", 2) == 3);
 assert("Dictu is great! Dictu is great!".find("Dictu") == 0);
+
+// Second occurrence
 assert("Dictu is great! Dictu is great!".find("Dictu", 2) == 16);
+
+// Third occurrence
 assert("Dictu is great! Dictu is great! Dictu is great!".find("Dictu", 3) == 37);
+
+// Doesn't exist
+assert("Dictu is great!".find("hello") == -1);
+assert("Dictu is great!".find("l") == -1);
+assert("Dictu is great!".find("hello") == -1);
+
+// Second occurrence
+assert("Dictu is great!".find("Dictu", 2) == -1);
+
+// Third occurrence
+assert("Dictu is great!Dictu is great!".find("Dictu", 3) == -1);

--- a/tests/strings/format.du
+++ b/tests/strings/format.du
@@ -1,3 +1,11 @@
+/**
+* format.du
+*
+* Testing the str.format() method
+*
+* .format() interpolates values into a string
+*/
+
 assert("hello {}".format("jason") == "hello jason");
 assert("hello {}".format(10) == "hello 10");
 assert("hello {}".format([10]) == "hello [10]");

--- a/tests/strings/import.du
+++ b/tests/strings/import.du
@@ -1,3 +1,9 @@
+/**
+* import.du
+*
+* General import file for all the operator tests
+*/
+
 import "tests/strings/replace.du";
 import "tests/strings/split.du";
 import "tests/strings/upper.du";

--- a/tests/strings/lower.du
+++ b/tests/strings/lower.du
@@ -1,3 +1,11 @@
+/**
+* lower.du
+*
+* Testing the str.lower() method
+*
+* .lower() returns a lowercase version of the given string
+*/
+
 assert("DiCtU".lower() == "dictu");
 assert("dictu".lower() == "dictu");
 assert("DICTU".lower() == "dictu");

--- a/tests/strings/replace.du
+++ b/tests/strings/replace.du
@@ -1,3 +1,11 @@
+/**
+* replace.du
+*
+* Testing the str.replace() method
+*
+* .replace() returns a new string with a given substring replaced with another
+*/
+
 assert("a".replace("a", "b") == "b");
 assert("aa".replace("aa", "b") == "b");
 assert("aaa".replace("aaa", "b") == "b");

--- a/tests/strings/split.du
+++ b/tests/strings/split.du
@@ -1,3 +1,11 @@
+/**
+* split.du
+*
+* Testing the str.split() method
+*
+* .split() returns a list of substrings split by a given delimiter
+*/
+
 assert("Dictu is great!".split(" ") == ["Dictu", "is", "great!"]);
 assert("Dictu,is,great!".split(",") == ["Dictu", "is", "great!"]);
 assert("Dictu--is--great!".split("--") == ["Dictu", "is", "great!"]);

--- a/tests/strings/startsWith.du
+++ b/tests/strings/startsWith.du
@@ -1,3 +1,11 @@
+/**
+* startsWith.du
+*
+* Testing the str.startsWith() method
+*
+* .startsWith() returns a boolean based on whether the string starts with a given substring
+*/
+
 assert("test".startsWith("t"));
 assert("test".startsWith("te"));
 assert("test".startsWith("test"));

--- a/tests/strings/strip.du
+++ b/tests/strings/strip.du
@@ -1,3 +1,13 @@
+/**
+* strip.du
+*
+* Testing the str.leftStrip() method
+* Testing the str.strip() method
+* Testing the str.rightStrip() method
+*
+* .(left/right)strip() returns a new string with whitespace characters removed from the start, end, or both of a string
+*/
+
 // Left strip
 assert("  Dictu is great!".leftStrip() == "Dictu is great!");
 assert("Dictu is great!  ".leftStrip() == "Dictu is great!  ");

--- a/tests/strings/upper.du
+++ b/tests/strings/upper.du
@@ -1,3 +1,11 @@
+/**
+* upper.du
+*
+* Testing the str.upper() method
+*
+* .upper() returns an uppercase version of the given string
+*/
+
 assert("DiCtU".upper() == "DICTU");
 assert("DICTU".upper() == "DICTU");
 assert("dictu".upper() == "DICTU");

--- a/tests/variables/assignment.du
+++ b/tests/variables/assignment.du
@@ -1,3 +1,9 @@
+/**
+* assignment.du
+*
+* Testing variable assignment
+*/
+
 var x = 10;
 assert(x == 10);
 

--- a/tests/variables/import.du
+++ b/tests/variables/import.du
@@ -1,2 +1,8 @@
+/**
+* import.du
+*
+* General import file for all the variable tests
+*/
+
 import "tests/variables/scope.du";
 import "tests/variables/assignment.du";

--- a/tests/variables/scope.du
+++ b/tests/variables/scope.du
@@ -1,3 +1,9 @@
+/**
+* scope.du
+*
+* Testing variable assignment within a scoped context
+*/
+
 // Test scope
 var x = 10;
 {


### PR DESCRIPTION
# Tests
The main addition is the addition of headers within each of the test files. However this PR also fixes a minor issue with `file.readLine()` as it was including the newline char. This PR also makes `dict.get()` not require a default value to be passed, if a key is not found and no default is passed, `nil` is returned instead.