### PR TITLE
Slight optimisation for invoke method

### DIFF
--- a/c/object.h
+++ b/c/object.h
@@ -186,4 +186,8 @@ static inline bool isObjType(Value value, ObjType type) {
     return IS_OBJ(value) && AS_OBJ(value)->type == type;
 }
 
+static inline ObjType getObjType(Value value) {
+    return AS_OBJ(value)->type;
+}
+
 #endif


### PR DESCRIPTION
# Slight optimisation
The invoke method is used to invoke methods on different types of variable. For example there may be a method on an instance, or a function on a string. In its current state this was determined via an if-elseif chain, which could require multiple branch conditions to be evaluated before finally arriving at the correct statement. This PR changes this by returning the object type, and switching on this type instead.