### PR TITLE
Fix printing lists and dictionaries

### DIFF
--- a/c/object.c
+++ b/c/object.c
@@ -29,7 +29,7 @@ static Obj *allocateObject(size_t size, ObjType type, bool garbageCollect) {
     vm.objects = object;
 
 #ifdef DEBUG_TRACE_GC
-    printf("%p allocate %ld for %d\n", (void *)object, size, type);
+    printf("%p allocate %zd for %d\n", (void *)object, size, type);
 #endif
 
     return object;
@@ -283,6 +283,7 @@ char *objectToString(Value value) {
 
         case OBJ_LIST: {
             int size = 50;
+            int listStringSize;
             ObjList *list = AS_LIST(value);
             char *listString = calloc(size, sizeof(char));
             snprintf(listString, 2, "%s", "[");
@@ -291,13 +292,13 @@ char *objectToString(Value value) {
                 char *element = valueToString(list->values.values[i]);
 
                 int elementSize = strlen(element);
-                int listStringSize = strlen(listString);
+                listStringSize = strlen(listString);
 
-                if (elementSize > (size - listStringSize - 1)) {
+                if (elementSize > (size - listStringSize - 3)) {
                     if (elementSize > size * 2) {
-                        size += elementSize * 2;
+                        size += elementSize * 2 + 3;
                     } else {
-                        size *= 2;
+                        size = size * 2 + 3;
                     }
 
                     char *newB = realloc(listString, sizeof(char) * size);
@@ -310,15 +311,18 @@ char *objectToString(Value value) {
                     listString = newB;
                 }
 
-                strncat(listString, element, size - listStringSize - 1);
+                snprintf(listString + listStringSize, size - listStringSize, "%s", element);
 
                 free(element);
 
-                if (i != list->values.count - 1)
-                    strncat(listString, ", ", size - listStringSize - 1);
+                if (i != list->values.count - 1) {
+                    listStringSize = strlen(listString);
+                    snprintf(listString + listStringSize, size - listStringSize, ", ");
+                }
             }
 
-            strncat(listString, "]", size - strlen(listString) - 1);
+            listStringSize = strlen(listString);
+            snprintf(listString + listStringSize, size - listStringSize, "]");
             return listString;
         }
 

--- a/c/object.c
+++ b/c/object.c
@@ -380,6 +380,8 @@ char *objectToString(Value value) {
 
                 dictStringLength += snprintf(dictString + dictStringLength, size - dictStringLength, "%s", element);
 
+                free(element);
+
                 if (count != dict->count) {
                     dictStringLength += snprintf(dictString + dictStringLength, size - dictStringLength, ", ");
                 }

--- a/c/object.c
+++ b/c/object.c
@@ -283,18 +283,16 @@ char *objectToString(Value value) {
 
         case OBJ_LIST: {
             int size = 50;
-            int listStringSize;
             ObjList *list = AS_LIST(value);
             char *listString = calloc(size, sizeof(char));
-            snprintf(listString, 2, "%s", "[");
+            int listStringLength = snprintf(listString, 2, "%s", "[");
 
             for (int i = 0; i < list->values.count; ++i) {
                 char *element = valueToString(list->values.values[i]);
 
                 int elementSize = strlen(element);
-                listStringSize = strlen(listString);
 
-                if (elementSize > (size - listStringSize - 3)) {
+                if (elementSize > (size - listStringLength - 3)) {
                     if (elementSize > size * 2) {
                         size += elementSize * 2 + 3;
                     } else {
@@ -311,18 +309,16 @@ char *objectToString(Value value) {
                     listString = newB;
                 }
 
-                snprintf(listString + listStringSize, size - listStringSize, "%s", element);
+                listStringLength += snprintf(listString + listStringLength, size - listStringLength, "%s", element);
 
                 free(element);
 
                 if (i != list->values.count - 1) {
-                    listStringSize = strlen(listString);
-                    snprintf(listString + listStringSize, size - listStringSize, ", ");
+                    listStringLength += snprintf(listString + listStringLength, size - listStringLength, ", ");
                 }
             }
 
-            listStringSize = strlen(listString);
-            snprintf(listString + listStringSize, size - listStringSize, "]");
+            snprintf(listString + listStringLength, size - listStringLength, "]");
             return listString;
         }
 
@@ -331,7 +327,7 @@ char *objectToString(Value value) {
             int size = 50;
             ObjDict *dict = AS_DICT(value);
             char *dictString = malloc(sizeof(char) * size);
-            snprintf(dictString, 2, "%s", "{");
+            int dictStringLength = snprintf(dictString, size, "%s", "{");
 
             for (int i = 0; i < dict->capacity; ++i) {
                 dictItem *item = dict->items[i];
@@ -341,10 +337,9 @@ char *objectToString(Value value) {
                 count++;
 
 
-                int keySize = strlen(item->key);
-                int dictStringSize = strlen(dictString);
+                int keySize = strlen(item->key) + 5;
 
-                if (keySize > (size - dictStringSize - 1)) {
+                if (keySize > (size - dictStringLength - 1)) {
                     if (keySize > size * 2) {
                         size += keySize * 2;
                     } else {
@@ -361,20 +356,16 @@ char *objectToString(Value value) {
                     dictString = newB;
                 }
 
-                char *dictKeyString = malloc(sizeof(char) * (strlen(item->key) + 5));
-                snprintf(dictKeyString, (strlen(item->key) + 5), "\"%s\": ", item->key);
-
-                strncat(dictString, dictKeyString, size - dictStringSize - 1);
-                free(dictKeyString);
+                dictStringLength += snprintf(dictString + dictStringLength, size - dictStringLength, "\"%s\": ", item->key);
 
                 char *element = valueToString(item->item);
                 int elementSize = strlen(element);
 
-                if (elementSize > (size - dictStringSize - 1)) {
+                if (elementSize > (size - dictStringLength - 3)) {
                     if (elementSize > size * 2) {
-                        size += elementSize * 2;
+                        size += elementSize * 2 + 3;
                     } else {
-                        size *= 2;
+                        size = size * 2 + 3;
                     }
 
                     char *newB = realloc(dictString, sizeof(char) * size);
@@ -387,15 +378,14 @@ char *objectToString(Value value) {
                     dictString = newB;
                 }
 
-                strncat(dictString, element, size - dictStringSize - 1);
+                dictStringLength += snprintf(dictString + dictStringLength, size - dictStringLength, "%s", element);
 
-                free(element);
-
-                if (count != dict->count)
-                    strncat(dictString, ", ", size - dictStringSize - 1);
+                if (count != dict->count) {
+                    dictStringLength += snprintf(dictString + dictStringLength, size - dictStringLength, ", ");
+                }
             }
 
-            strncat(dictString, "}", size - strlen(dictString) - 1);
+            snprintf(dictString + dictStringLength, size - dictStringLength, "}");
             return dictString;
         }
 


### PR DESCRIPTION
# Printing
Currently printing large lists causes a segfault, this is obviously not ideal 😄 This PR fixes this by removing the strncat functions and replacing it for snprintf for string concatenation.

Resolves #57 