### PR TITLE
Cleanup

### DIFF
--- a/c/natives.c
+++ b/c/natives.c
@@ -157,8 +157,6 @@ static Value sumNative(int argCount, Value *args) {
 }
 
 static Value minNative(int argCount, Value *args) {
-    double current;
-
     if (argCount == 0) {
         return NUMBER_VAL(0);
     } else if (argCount == 1 && IS_LIST(args[0])) {
@@ -176,7 +174,7 @@ static Value minNative(int argCount, Value *args) {
             return NIL_VAL;
         }
 
-        current = AS_NUMBER(value);
+        double current = AS_NUMBER(value);
 
         if (minimum > current) {
             minimum = current;
@@ -345,6 +343,11 @@ static Value inputNative(int argCount, Value *args) {
         if (i == current_size) {
             current_size = i + len_max;
             line = realloc(line, current_size);
+
+            if (line == NULL) {
+                printf("Unable to allocate memory\n");
+                exit(71);
+            }
         }
     }
 

--- a/c/scanner.c
+++ b/c/scanner.c
@@ -91,12 +91,12 @@ static void skipWhitespace() {
 
             case '/':
                 if (peekNext() == '*') {
-                    char c;
                     // Multiline comments
                     advance();
                     advance();
                     while (true) {
                         while (peek() != '*' && !isAtEnd()) {
+                            char c;
                             if ((c = advance()) == '\n') {
                                 scanner.line++;
                             }

--- a/c/strings.c
+++ b/c/strings.c
@@ -319,7 +319,7 @@ static bool rightStripString(int argCount) {
         }
     }
 
-    strncpy(temp, string->chars, length + 1);
+    snprintf(temp, string->length + 1, "%s", string->chars);
     temp[length + 1] = '\0';
     push(OBJ_VAL(copyString(temp, strlen(temp))));
     free(temp);
@@ -383,7 +383,6 @@ static bool formatString(int argCount) {
         }
 
         free(replace_strings);
-
         return false;
     }
 
@@ -393,20 +392,15 @@ static bool formatString(int argCount) {
     char *tmp1Free = tmp1;
     strcpy(tmp1, string);
     char *newStr = malloc(sizeof(char) * fullLength);
+    int stringLength = 0;
 
     for (int i = 0; i < argCount - 1; ++i) {
         pos = strstr(tmp1, "{}");
         if (pos != NULL)
             *pos = '\0';
 
-        if (i == 0)
-            snprintf(newStr, fullLength, "%s", tmp1);
-        else
-            strncat(newStr, tmp1, strlen(tmp1));
-
-        strncat(newStr, replace_strings[i], strlen(replace_strings[i]));
+        stringLength += snprintf(newStr + stringLength, fullLength - stringLength, "%s%s", tmp1, replace_strings[i]);
         tmp1 = pos + 2;
-
         free(replace_strings[i]);
     }
 
@@ -423,7 +417,9 @@ static bool formatString(int argCount) {
 }
 
 bool stringMethods(char *method, int argCount) {
-    if (strcmp(method, "split") == 0) {
+    if (strcmp(method, "format") == 0) {
+        return formatString(argCount);
+    } else if (strcmp(method, "split") == 0) {
         return splitString(argCount);
     } else if (strcmp(method, "contains") == 0) {
         return containsString(argCount);
@@ -445,8 +441,6 @@ bool stringMethods(char *method, int argCount) {
         return rightStripString(argCount);
     } else if (strcmp(method, "strip") == 0) {
         return stripString(argCount);
-    } else if (strcmp(method, "format") == 0) {
-        return formatString(argCount);
     }
 
     runtimeError("String has no method %s()", method);

--- a/c/strings.c
+++ b/c/strings.c
@@ -293,10 +293,9 @@ static bool rightStripString(int argCount) {
         runtimeError("rightStrip() takes 1 argument (%d  given)", argCount);
         return false;
     }
+
     ObjString *string = AS_STRING(pop());
-
     int length;
-
     char *temp = malloc(sizeof(char) * (string->length + 1));
 
     for (length = string->length - 1; length > 0; --length) {
@@ -305,9 +304,8 @@ static bool rightStripString(int argCount) {
         }
     }
 
-    snprintf(temp, string->length + 1, "%s", string->chars);
-    temp[length + 1] = '\0';
-    push(OBJ_VAL(copyString(temp, strlen(temp))));
+    memcpy(temp, string->chars, length + 1);
+    push(OBJ_VAL(copyString(temp, length + 1)));
     free(temp);
     return true;
 }

--- a/c/strings.c
+++ b/c/strings.c
@@ -143,7 +143,7 @@ static bool replaceString(int argCount) {
     // Make a copy of the string so we do not modify the original
     char *tmp = malloc(stringLen);
     char *tmpFree = tmp;
-    snprintf(tmp, stringLen, "%s", string);
+    memcpy(tmp, string, stringLen);
 
     while((tmp = strstr(tmp, to_replace)) != NULL) {
         count++;
@@ -157,8 +157,6 @@ static bool replaceString(int argCount) {
         push(stringValue);
         return true;
     }
-
-    // snprintf(tmp, stringLen, "%s", string);
 
     int length = strlen(tmp) - count * (len - strlen(replace)) + 1;
     char *pos;
@@ -341,7 +339,7 @@ static bool formatString(int argCount) {
         else {
             ObjString *strObj = AS_STRING(value);
             char *str = malloc(strObj->length + 1);
-            snprintf(str, strObj->length + 1, "%s", strObj->chars);
+            memcpy(str, strObj->chars, strObj->length + 1);
             replace_strings[j] = str;
         }
 
@@ -353,7 +351,7 @@ static bool formatString(int argCount) {
     int stringLen = strlen(string) + 1;
     char *tmp = malloc(stringLen);
     char *tmpFree = tmp;
-    snprintf(tmp, stringLen, "%s", string);
+    memcpy(tmp, string, stringLen);
 
     int count = 0;
     while((tmp = strstr(tmp, "{}")))

--- a/c/strings.c
+++ b/c/strings.c
@@ -14,11 +14,11 @@ static bool splitString(int argCount) {
     }
 
     char *delimiter = AS_CSTRING(pop());
-    char *string = AS_CSTRING(pop());
-    char *tmp = malloc(strlen(string) + 1);
+    ObjString *string = AS_STRING(pop());
+    char *tmp = malloc(string->length + 1);
     char *tmpFree = tmp;
-    strcpy(tmp, string);
-
+    memcpy(tmp, string->chars, string->length + 1);
+    int delimiterLength = strlen(delimiter);
     char *token;
 
     ObjList *list = initList(false);
@@ -41,7 +41,7 @@ static bool splitString(int argCount) {
         array->values[array->count] = OBJ_VAL(str);
         array->count++;
 
-        tmp = token + strlen(delimiter);
+        tmp = token + delimiterLength;
     } while (token != NULL);
 
     free(tmpFree);

--- a/c/vm.c
+++ b/c/vm.c
@@ -205,6 +205,11 @@ static bool invokeFromClass(ObjClass *klass, ObjString *name,
 static bool invoke(ObjString *name, int argCount) {
     Value receiver = peek(argCount);
 
+    if (!IS_OBJ(receiver)) {
+        runtimeError("Can only invoke on objects.");
+        return false;
+    }
+
     switch (getObjType(receiver)) {
         case OBJ_CLASS: {
             ObjClass *instance = AS_CLASS(receiver);

--- a/tests/benchmarks/format.du
+++ b/tests/benchmarks/format.du
@@ -1,0 +1,8 @@
+var start = clock();
+var x;
+
+for (var i = 0; i < 10000; ++i) {
+    x = "{} {}".format("test", "test");
+}
+
+print(clock() - start);


### PR DESCRIPTION
# Cleanup
This PR turned into a general cleanup in a few areas, but mainly for the string methods.
- Remove some malloc calls that are not needed
- Change some snprintf's to memcpy's
- Add a new format.du benchmark
- Add error checking for invoking non objects
- Add error checking for a malloc call

Resolves #59 

### Note about the format benchmark
Currently the average time i was getting for the format benchmark was around the ~0.012s mark. This is really slow in comparison to the python counterpart at ~0.005 seconds. This has highlighted that some string functions will need to be revisited at a later date.