### PR TITLE
Add lists and dicts to falsey value check

### DIFF
--- a/c/value.c
+++ b/c/value.c
@@ -193,7 +193,7 @@ static bool dictComparison(Value a, Value b) {
     ObjDict *dictB = AS_DICT(b);
 
     // Different lengths, not the same
-    if (dict->capacity != dictB->capacity)
+    if (dict->count != dictB->count)
         return false;
 
     // Lengths are the same, and dict 1 has 0 length

--- a/c/vm.c
+++ b/c/vm.c
@@ -354,7 +354,9 @@ bool isFalsey(Value value) {
     return IS_NIL(value) ||
            (IS_BOOL(value) && !AS_BOOL(value)) ||
            (IS_NUMBER(value) && AS_NUMBER(value) == 0) ||
-           (IS_STRING(value) && AS_CSTRING(value)[0] == '\0');
+           (IS_STRING(value) && AS_CSTRING(value)[0] == '\0') ||
+           (IS_LIST(value) && AS_LIST(value)->values.count == 0) ||
+           (IS_DICT(value) && AS_DICT(value)->count == 0);
 }
 
 static void concatenate() {

--- a/tests/operators/equality.du
+++ b/tests/operators/equality.du
@@ -23,9 +23,9 @@ assert([10] == [10]);
 assert([] != [10]);
 assert([10] != [100]);
 
-// assert({} == {});
+assert({} == {});
 assert({"test": 10} == {"test": 10});
-// assert({} != {"test": 10}); TODO: Known issue with dictionary parsing
+assert({} != {"test": 10});
 assert({"test": 10} != {"test": 100});
 
 def test() {}


### PR DESCRIPTION
Currently `bool([])` and `bool({})` give `true` back, and empty lists/dictionaries are falsey values. This is due to the `isFalsey` not checking for empty lists/dictionaries. 