### PR TITLE
Add additional check to ensure value is an object before subscripting

### DIFF
--- a/c/vm.c
+++ b/c/vm.c
@@ -858,11 +858,17 @@ static InterpretResult run() {
             Value indexValue = pop();
             Value subscriptValue = pop();
 
+            if (!IS_OBJ(subscriptValue)) {
+                frame->ip = ip;
+                runtimeError("Can only subscript on lists, strings or dictionaries.");
+                return INTERPRET_RUNTIME_ERROR;
+            }
+
             switch (getObjType(subscriptValue)) {
                 case OBJ_LIST: {
                     if (!IS_NUMBER(indexValue)) {
                         frame->ip = ip;
-                        runtimeError("Array index must be a number.");
+                        runtimeError("List index must be a number.");
                         return INTERPRET_RUNTIME_ERROR;
                     }
 
@@ -879,7 +885,7 @@ static InterpretResult run() {
                     }
 
                     frame->ip = ip;
-                    runtimeError("Array index out of bounds.");
+                    runtimeError("List index out of bounds.");
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
@@ -897,7 +903,7 @@ static InterpretResult run() {
                     }
 
                     frame->ip = ip;
-                    runtimeError("Array index out of bounds.");
+                    runtimeError("String index out of bounds.");
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
@@ -929,11 +935,17 @@ static InterpretResult run() {
             Value indexValue = pop();
             Value subscriptValue = pop();
 
+            if (!IS_OBJ(subscriptValue)) {
+                frame->ip = ip;
+                runtimeError("Can only subscript on lists, strings or dictionaries.");
+                return INTERPRET_RUNTIME_ERROR;
+            }
+
             switch (getObjType(subscriptValue)) {
                 case OBJ_LIST: {
                     if (!IS_NUMBER(indexValue)) {
                         frame->ip = ip;
-                        runtimeError("Array index must be a number.");
+                        runtimeError("List index must be a number.");
                         return INTERPRET_RUNTIME_ERROR;
                     }
 
@@ -952,7 +964,7 @@ static InterpretResult run() {
                     push(NIL_VAL);
 
                     frame->ip = ip;
-                    runtimeError("Array index out of bounds.");
+                    runtimeError("List index out of bounds.");
                     return INTERPRET_RUNTIME_ERROR;
                 }
 
@@ -985,11 +997,17 @@ static InterpretResult run() {
             Value indexValue = pop();
             Value subscriptValue = pop();
 
+            if (!IS_OBJ(subscriptValue)) {
+                frame->ip = ip;
+                runtimeError("Can only subscript on lists, strings or dictionaries.");
+                return INTERPRET_RUNTIME_ERROR;
+            }
+
             switch (getObjType(subscriptValue)) {
                 case OBJ_LIST: {
                     if (!IS_NUMBER(indexValue)) {
                         frame->ip = ip;
-                        runtimeError("Array index must be a number.");
+                        runtimeError("List index must be a number.");
                         return INTERPRET_RUNTIME_ERROR;
                     }
 
@@ -1009,7 +1027,7 @@ static InterpretResult run() {
                     }
 
                     frame->ip = ip;
-                    runtimeError("Array index out of bounds.");
+                    runtimeError("List index out of bounds.");
                     return INTERPRET_RUNTIME_ERROR;
                 }
 

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -82,7 +82,7 @@ list2[0] = 10;
 print(list1); // [1, 2]
 print(list2); // [10, 2]
 ```
-This works fine, however if you have a mutable datatype within the array on a shallow copy, you're back to square one.
+This works fine, however if you have a mutable datatype within the list on a shallow copy, you're back to square one.
 ```js
 var list1 = [[1, 2];
 var list2 = list1.copy();


### PR DESCRIPTION
# Resolve segfault on subscripting a non-object

Resolves #70 

### Summary
Currently dictu does not have explicit checking to ensure that the object you are going to subscript on is actually an object, this is assumed. This is an issue because attempting to subscript on primitive types causes a segfault rather than a runtime error.

### Changes
This PR introduces explicit checking for objects when attempting to subscript on an object and produce a viable runtime error if not. This PR also changes all user facing occurrences of "Array" to "List" to be consistent throughout.