### PR TITLE
Only create a dictionary if the advanced token is a colon

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -1482,8 +1482,6 @@ static void whileStatement() {
 
     if (check(TOKEN_LEFT_BRACE)) {
         emitByte(OP_TRUE);
-
-        //emitByte(OP_POP);
     } else {
         consume(TOKEN_LEFT_PAREN, "Expect '(' after 'while'.");
         expression();
@@ -1570,16 +1568,11 @@ static void statement() {
     } else if (match(TOKEN_LEFT_BRACE)) {
         Token previous = parser.previous;
         Token current = parser.current;
-        if (check(TOKEN_STRING)) {
-            for (int i = 0; i < parser.current.length - parser.previous.length + 1; ++i) {
-                backTrack();
-            }
 
-            parser.current = previous;
-            expressionStatement();
-            return;
-        } else if (check(TOKEN_RIGHT_BRACE)) {
-            advance();
+        // Advance the parser to the next token
+        advance();
+
+        if (check(TOKEN_RIGHT_BRACE)) {
             if (check(TOKEN_SEMICOLON)) {
                 backTrack();
                 backTrack();
@@ -1588,6 +1581,24 @@ static void statement() {
                 return;
             }
         }
+
+        if (check(TOKEN_COLON)) {
+            for (int i = 0; i < parser.current.length + parser.previous.length; ++i) {
+                backTrack();
+            }
+
+            parser.current = previous;
+            expressionStatement();
+            return;
+        }
+
+        // Reset the scanner to the previous position
+        for (int i = 0; i < parser.current.length; ++i) {
+            backTrack();
+        }
+
+        // Reset the parser
+        parser.previous = previous;
         parser.current = current;
 
         beginScope();


### PR DESCRIPTION
# Fix dictionary parsing

Resolves #44 

## Summary
Currently the syntax for creating a dictionary is a `<left brace> + <string>` combination, however there are cases where this could produce a false positive, e.g:
```js
for (var i = 0; i < 10; ++i) {
    "string";
}
```
This combination also does not allow dictionaries keys to be extended at a later date to other value types as the compiler is explicitly looking for a string token. Instead this PR advances the parser one token and checks for a colon, `<left brace> + <TOKEN> + <colon>`, and this is the basis for forming a dictionary. This means `<TOKEN>` can be of any type allowing the addition of more value types for dictionary keys, along with fixing the bug in the first code block.