### PR TITLE
Multiline REPL

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -64,12 +64,11 @@ static bool replCountQuotes(char *line) {
 static void repl() {
     printf(VERSION);
     char *line;
-    char *fullLine;
 
     linenoiseHistoryLoad("history.txt");
 
     while((line = linenoise(">>> ")) != NULL) {
-        fullLine = malloc(sizeof(char) * (strlen(line) + 1));
+        char *fullLine = malloc(sizeof(char) * (strlen(line) + 1));
         snprintf(fullLine, strlen(line) + 1, "%s", line);
 
         linenoiseHistoryAdd(line);

--- a/c/main.c
+++ b/c/main.c
@@ -12,12 +12,21 @@
 
 #define VERSION "Dictu Version: 0.1.7\n"
 
-
+// TODO: Ignore braces in strings
 static bool replCountBraces(char *line) {
     int leftBraces = 0;
     int rightBraces = 0;
+    bool inString = false;
 
     for (int i = 0; line[i]; i++) {
+        if (line[i] == '\'' || line[i] == '"') {
+            inString = !inString;
+        }
+
+        if (inString) {
+            continue;
+        }
+
         if (line[i] == '{') {
             leftBraces++;
         } else if (line[i] == '}') {

--- a/c/main.c
+++ b/c/main.c
@@ -50,8 +50,15 @@ static void repl() {
                 return;
             }
 
-            fullLine = realloc(fullLine, strlen(fullLine) + strlen(line) + 1);
-            snprintf(fullLine, strlen(fullLine) + strlen(line) + 1, "%s%s", fullLine, line);
+            char *temp = realloc(fullLine, strlen(fullLine) + strlen(line) + 1);
+
+            if (temp == NULL) {
+                printf("Unable to allocate memory");
+                exit(71);
+            }
+
+            fullLine = temp;
+            memcpy(fullLine + strlen(fullLine), line, strlen(line) + 1);
 
             linenoiseHistoryAdd(line);
             linenoiseHistorySave("history.txt");

--- a/c/main.c
+++ b/c/main.c
@@ -12,7 +12,6 @@
 
 #define VERSION "Dictu Version: 0.1.7\n"
 
-// TODO: Ignore braces in strings
 static bool replCountBraces(char *line) {
     int leftBraces = 0;
     int rightBraces = 0;
@@ -37,6 +36,31 @@ static bool replCountBraces(char *line) {
     return leftBraces == rightBraces;
 }
 
+static bool replCountQuotes(char *line) {
+    int singleQuotes = 0;
+    int doubleQuotes = 0;
+    char quote = '\0';
+
+    for (int i = 0; line[i]; i++) {
+        if (line[i] == '\'' && quote != '"') {
+            singleQuotes++;
+
+            if (quote == '\0') {
+                quote = '\'';
+            }
+        } else if (line[i] == '"' && quote != '\'') {
+            doubleQuotes++;
+            if (quote == '\0') {
+                quote = '"';
+            }
+        } else if (line[i] == '\\') {
+            line++;
+        }
+    }
+
+    return singleQuotes % 2 == 0 && doubleQuotes % 2 == 0;
+}
+
 static void repl() {
     printf(VERSION);
     char *line;
@@ -51,7 +75,7 @@ static void repl() {
         linenoiseHistoryAdd(line);
         linenoiseHistorySave("history.txt");
 
-        while (!replCountBraces(fullLine)) {
+        while (!replCountBraces(fullLine) || !replCountQuotes(fullLine)) {
             free(line);
             line = linenoise("... ");
 

--- a/c/main.c
+++ b/c/main.c
@@ -12,17 +12,55 @@
 
 #define VERSION "Dictu Version: 0.1.7\n"
 
+
+static bool replCountBraces(char *line) {
+    int leftBraces = 0;
+    int rightBraces = 0;
+
+    for (int i = 0; line[i]; i++) {
+        if (line[i] == '{') {
+            leftBraces++;
+        } else if (line[i] == '}') {
+            rightBraces++;
+        }
+    }
+
+    return leftBraces == rightBraces;
+}
+
 static void repl() {
     printf(VERSION);
     char *line;
+    char *fullLine;
 
     linenoiseHistoryLoad("history.txt");
 
     while((line = linenoise(">>> ")) != NULL) {
-        interpret(line);
+        fullLine = malloc(sizeof(char) * (strlen(line) + 1));
+        snprintf(fullLine, strlen(line) + 1, "%s", line);
+
         linenoiseHistoryAdd(line);
         linenoiseHistorySave("history.txt");
+
+        while (!replCountBraces(fullLine)) {
+            free(line);
+            line = linenoise("... ");
+
+            if (line == NULL) {
+                return;
+            }
+
+            fullLine = realloc(fullLine, strlen(fullLine) + strlen(line) + 1);
+            snprintf(fullLine, strlen(fullLine) + strlen(line) + 1, "%s%s", fullLine, line);
+
+            linenoiseHistoryAdd(line);
+            linenoiseHistorySave("history.txt");
+        }
+
+        interpret(fullLine);
+
         free(line);
+        free(fullLine);
     }
 }
 


### PR DESCRIPTION
# Multiline REPL
Resolves #74

## Summary
This PR introduces multiline code blocks into the REPL. This is done based on the amount of opened and closed braces.
e.g
```
>>> print("hello");
'hello'
```
Opened and closed braces are equal (0), so this is treat as a single line.
```
>>> def test() {print("hello");}
```
Opened and closed braces are equal (1 for each), so this is treat as a single line.
```
>>> def test() {
...     print("hello");
... }
```
Opened and closed braces are **not** equal (1 open on the first line, none until closing function), so this is treat as a multiline until the braces are equal.

The REPL also has support for multiline strings (either single or double quotes). The concept is similar to the braces. If there is an unterminated string it will continue until the string is correctly terminated. (Ignores escaped strings, and mismatching quotes)

```
>>> 'This
... is
... my
... test
... string';
'Thisismyteststring'
```

```
>>> "This
... is
... my
... test
... string";
'Thisismyteststring'
```