### PR TITLE
Fix issue with dict.exists()

### DIFF
--- a/c/datatypes/dicts.c
+++ b/c/datatypes/dicts.c
@@ -87,7 +87,7 @@ static bool dictItemExists(int argCount) {
         if (!dict->items[i])
             continue;
 
-        if (strcmp(dict->items[i]->key, key) == 0) {
+        if (strcmp(dict->items[i]->key, key) == 0 && !dict->items[i]->deleted) {
             push(TRUE_VAL);
             return true;
         }


### PR DESCRIPTION
# dict.exists() issue

Resolves #79 

Currently .exists() for dictionaries does not take into account "deleted" entries. This PR changes the check to ensure a "deleted" value does not exist.