### PR TITLE
Grow CallFrames dynamically

### DIFF
--- a/c/value.c
+++ b/c/value.c
@@ -189,8 +189,6 @@ void insertSet(ObjSet *set, Value value) {
         if (index == set->capacity) {
             index = 0;
         }
-
-        printf("skip\n");
     }
 
     set->items[index] = item;

--- a/c/vm.c
+++ b/c/vm.c
@@ -82,6 +82,7 @@ void initVM(bool repl, const char *scriptName) {
 void freeVM() {
     freeTable(&vm.globals);
     freeTable(&vm.strings);
+    FREE_ARRAY(CallFrame, vm.frames, vm.frameCapacity);
     vm.initString = NULL;
     vm.replVar = NULL;
     vm.gc = NULL;

--- a/c/vm.h
+++ b/c/vm.h
@@ -4,10 +4,8 @@
 #include "object.h"
 #include "table.h"
 #include "value.h"
-// TODO: Don't depend on frame count for stack count since we have
-// stack before frames?
-#define FRAMES_MAX 64
-#define STACK_MAX (FRAMES_MAX * UINT8_COUNT)
+// TODO: Work out the maximum stack size at compilation time
+#define STACK_MAX (64 * UINT8_COUNT)
 
 typedef struct {
     ObjClosure *closure;
@@ -23,8 +21,9 @@ typedef struct {
     bool gc;
     const char *scriptName;
     const char *currentScriptName;
-    CallFrame frames[FRAMES_MAX];
+    CallFrame *frames;
     int frameCount;
+    int frameCapacity;
     int currentFrameCount;
     Table globals;
     Table strings;


### PR DESCRIPTION
# CallFrames
Resolves #60 
## Summary
Currently `FRAMES_MAX` is a constant (64), meaning, if we get a chain of functions "nesting" to 64 layers we will end up running into a runtime error saying we have overflowed the stack. This PR addresses this by growing the CallFrames within the VM as needed. 