### PR TITLE
Import cache

### DIFF
--- a/c/vm.h
+++ b/c/vm.h
@@ -27,6 +27,7 @@ typedef struct {
     int currentFrameCount;
     Table globals;
     Table strings;
+    Table imports;
     ObjString *initString;
     ObjString *replVar;
     ObjUpvalue *openUpvalues;


### PR DESCRIPTION
# Import cache
Resolves #91 
## Summary
If we have already imported a file, we do not want to run the entire import process again if another script ends up including the same file; instead we want to track the imported files and simply skip the process if we have already imported the file. Thats what this PR does by keeping an internal hashtable of imported files and skipping the import process if needs be.