### PR TITLE
CLI args

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -61,7 +61,7 @@ static bool replCountQuotes(char *line) {
     return singleQuotes % 2 == 0 && doubleQuotes % 2 == 0;
 }
 
-static void repl() {
+static void repl(int argc, const char *argv[]) {
     printf(VERSION);
     char *line;
 
@@ -96,16 +96,16 @@ static void repl() {
             linenoiseHistorySave("history.txt");
         }
 
-        interpret(fullLine);
+        interpret(fullLine, argc, argv);
 
         free(line);
         free(fullLine);
     }
 }
 
-static void runFile(const char *path) {
-    char *source = readFile(path);
-    InterpretResult result = interpret(source);
+static void runFile(int argc, const char *argv[]) {
+    char *source = readFile(argv[1]);
+    InterpretResult result = interpret(source, argc, argv);
     free(source); // [owner]
 
     if (result == INTERPRET_COMPILE_ERROR) exit(65);
@@ -113,14 +113,14 @@ static void runFile(const char *path) {
 }
 
 int main(int argc, const char *argv[]) {
-    initVM(argc == 1, argc == 2 ? argv[1] : "repl");
+    initVM(argc == 1, argc >= 2 ? argv[1] : "repl");
 
     if (argc == 1) {
-        repl();
-    } else if (argc == 2) {
-        runFile(argv[1]);
+        repl(argc, argv);
+    } else if (argc >= 2) {
+        runFile(argc, argv);
     } else {
-        fprintf(stderr, "Usage: dictu [path]\n");
+        fprintf(stderr, "Usage: dictu [path] [args]\n");
         exit(64);
     }
 

--- a/c/vm.h
+++ b/c/vm.h
@@ -30,6 +30,7 @@ typedef struct {
     Table imports;
     ObjString *initString;
     ObjString *replVar;
+    ObjString *argv;
     ObjUpvalue *openUpvalues;
     size_t bytesAllocated;
     size_t nextGC;
@@ -51,7 +52,7 @@ void initVM(bool repl, const char *scriptName);
 
 void freeVM();
 
-InterpretResult interpret(const char *source);
+InterpretResult interpret(const char *source, int argc, const char *argv[]);
 
 void push(Value value);
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -70,3 +70,29 @@ comment
 ```
 
 {: .no_toc }
+
+## Argv
+
+Passing arguments to the script via the CLI is very important, especially in a headless environment. Dictu allows you to access these arguments very easily with the magic `argv` variable. `argv` is a list of all arguments supplied to the script. This will be more apparent with the following examples. Note - the first element of the argv list is always the script name.
+
+#### CLI
+
+`./dictu myFile.du`
+
+```js
+# myFile.du
+
+print(argv); // ["myDile.du"]
+```
+
+`./dictu myFile.du arg1 arg2 arg3`
+
+```js
+# myFile.du
+
+print(argv); // ["myDile.du", "arg1", "arg2", "arg3"]
+```
+
+
+
+ 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -77,7 +77,7 @@ Passing arguments to the script via the CLI is very important, especially in a h
 
 `./dictu myFile.du`
 
-```
+```js
 # myFile.du
 
 print(argv); // ["myDile.du"]

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -69,17 +69,15 @@ comment
 */
 ```
 
-{: .no_toc }
-
 ## Argv
 
 Passing arguments to the script via the CLI is very important, especially in a headless environment. Dictu allows you to access these arguments very easily with the magic `argv` variable. `argv` is a list of all arguments supplied to the script. This will be more apparent with the following examples. Note - the first element of the argv list is always the script name.
 
-#### CLI
+### CLI
 
 `./dictu myFile.du`
 
-```js
+```
 # myFile.du
 
 print(argv); // ["myDile.du"]
@@ -93,6 +91,4 @@ print(argv); // ["myDile.du"]
 print(argv); // ["myDile.du", "arg1", "arg2", "arg3"]
 ```
 
-
-
- 
+{: .no_toc }

--- a/tests/variables/import.du
+++ b/tests/variables/import.du
@@ -6,3 +6,4 @@
 
 import "tests/variables/scope.du";
 import "tests/variables/assignment.du";
+import "tests/variables/magic.du";

--- a/tests/variables/magic.du
+++ b/tests/variables/magic.du
@@ -1,0 +1,11 @@
+/**
+ * magic.du
+ *
+ * Testing "magic" variables are set correctly
+ */
+
+/**
+ * argv is a list of all parameters passed to the interpreter.
+ * The first element is always the script name
+ */
+assert(argv == ["tests/runTests.du"]);


### PR DESCRIPTION
# CLI args
Resolves #77 
## Summary
Currently there is no way to supply user input to a script via the command line, and only with input(). This means in a headless environment there is no real way to customise what is ran for a script (unless using files, which isn't great). This PR changes this by introducing a new "magic" `argv` variable which is a list containing all the arguments passed to the script.
### Examples
`./dictu myFile.du`

```js
# myFile.du

print(argv); // ["myDile.du"]
```

`./dictu myFile.du arg1 arg2 arg3`

```js
# myFile.du

print(argv); // ["myDile.du", "arg1", "arg2", "arg3"]
```
Note: The variable is undefined in the REPL.