### PR TITLE
Attribute checking

### DIFF
--- a/c/vm.c
+++ b/c/vm.c
@@ -262,8 +262,32 @@ static bool invoke(ObjString *name, int argCount) {
         case OBJ_INSTANCE: {
             ObjInstance *instance = AS_INSTANCE(receiver);
 
-            // First look for a field which may shadow a method.
             Value value;
+            if (strcmp(name->chars, "hasAttribute") == 0) {
+                if (argCount != 1) {
+                    runtimeError("hasAttribute() takes 1 argument (%d  given)", argCount);
+                    return false;
+                }
+
+                Value value = pop(); // Pop the "attribute"
+                pop(); // Pop the instance
+
+                if (!IS_STRING(value)) {
+                    runtimeError("Argument passed to hasAttribute() must be a string");
+                    return false;
+                }
+
+                if (tableGet(&instance->fields, AS_STRING(value), &value)) {
+                    push(TRUE_VAL);
+                } else {
+                    push(FALSE_VAL);
+                }
+
+                return true;
+            }
+
+            // First look for a field which may shadow a method.
+
             if (tableGet(&instance->fields, name, &value)) {
                 vm.stackTop[-argCount] = value;
                 return callValue(value, argCount);

--- a/docs/docs/classes.md
+++ b/docs/docs/classes.md
@@ -82,6 +82,39 @@ var myObject = SomeClass("Some text!");
 myObject.printMessage(); // Some text!
 ```
 
+## Attributes
+
+Attributes in Dictu are instance attributes, and these attributes get defined either inside the methods or on the method directly. There is no concept of attribute access modifiers in python and attributes
+are available directly from the object without the need for getters or setters.
+
+```js
+class Test {
+    init() {
+        this.x = 10;
+    }
+}
+
+var myObject = Test();
+print(myObject.x); // 10
+```
+
+Attempting to access an attribute of an object that does not exist will throw a runtime error, and instead before accessing, you should check
+if the object has the given attribute. This is done via `hasAttribute`.
+
+```js
+class Test {
+    init() {
+        this.x = 10;
+    }
+}
+
+var myObject = Test();
+print(myObject.hasAttribute("x")); // true
+print(myObject.hasAttribute("y")); // false
+
+print(myObject.z); // Undefined property 'z'.
+```
+
 ## Static methods
 
 Static methods are methods which do not reference an object, and instead belong to a class. If a method is marked as static, `this` is not passed to the object. This means static methods can be invoked without instantiating an object.

--- a/tests/classes/properties.du
+++ b/tests/classes/properties.du
@@ -31,3 +31,6 @@ assert(obj.x == 20);
 assert(obj.x == 21);
 --obj.x;
 assert(obj.x == 20);
+
+assert(obj.hasAttribute("x"));
+assert(!obj.hasAttribute("y"));


### PR DESCRIPTION
# Attribute Checking
Resolves #95
## Summary
This PR adds in a new method on instances: `hasAttribute()`. This allows us to check at runtime whether an object has a given attribute or not.
e.g
```js
class Test {
    init() {
        this.x = 10;
    }
}
var myObject = Test();
print(myObject.hasAttribute("x")); // true
print(myObject.hasAttribute("y")); // false
``` 
This PR also adds documentation about how attributes work within Dictu.