### PR TITLE
Add getAttribute and hasAttribute

### DIFF
--- a/c/datatypes/instance.c
+++ b/c/datatypes/instance.c
@@ -1,0 +1,94 @@
+#include "instance.h"
+#include "../vm.h"
+#include "../memory.h"
+
+static bool hasAttribute(int argCount) {
+    if (argCount != 2) {
+        runtimeError("hasAttribute() takes 2 arguments (%d  given)", argCount);
+        return false;
+    }
+
+    Value value = pop(); // Pop the "attribute"
+    ObjInstance *instance = AS_INSTANCE(pop()); // Pop the instance
+
+    if (!IS_STRING(value)) {
+        runtimeError("Argument passed to hasAttribute() must be a string");
+        return false;
+    }
+
+    Value _; // Unused variable
+    if (tableGet(&instance->fields, AS_STRING(value), &_)) {
+        push(TRUE_VAL);
+    } else {
+        push(FALSE_VAL);
+    }
+
+    return true;
+}
+
+static bool getAttribute(int argCount) {
+    if (argCount != 2 && argCount != 3) {
+        runtimeError("getAttribute() takes 2 or 3 arguments (%d  given)", argCount);
+        return false;
+    }
+
+    Value defaultValue = NIL_VAL;
+    // Passed in a default value
+    if (argCount == 3) {
+        defaultValue = pop();
+    }
+
+    Value key = pop();
+
+    if (!IS_STRING(key)) {
+        runtimeError("Argument passed to getAttribute() must be a string");
+        return false;
+    }
+
+    ObjInstance *instance = AS_INSTANCE(pop()); // Pop the instance
+
+    Value value;
+    if (tableGet(&instance->fields, AS_STRING(key), &value)) {
+        push(value);
+    } else {
+        push(defaultValue);
+    }
+
+    return true;
+}
+
+static bool setAttribute(int argCount) {
+    if (argCount != 3) {
+        runtimeError("setAttribute() takes 3 (%d  given)", argCount);
+        return false;
+    }
+
+    Value value = pop();
+    Value key = pop();
+
+    if (!IS_STRING(key)) {
+        runtimeError("Argument passed to setAttribute() must be a string");
+        return false;
+    }
+
+    ObjInstance *instance = AS_INSTANCE(pop()); // Pop the instance
+
+    tableSet(&instance->fields, AS_STRING(key), value);
+
+    push(NIL_VAL);
+
+    return true;
+}
+
+
+bool instanceMethods(char *method, int argCount) {
+    if (strcmp(method, "hasAttribute") == 0) {
+        return hasAttribute(argCount);
+    } else if (strcmp(method, "getAttribute") == 0) {
+        return getAttribute(argCount);
+    } else if (strcmp(method, "setAttribute") == 0) {
+        return setAttribute(argCount);
+    }
+
+    return false;
+}

--- a/c/datatypes/instance.h
+++ b/c/datatypes/instance.h
@@ -1,0 +1,11 @@
+#ifndef dictu_instance_h
+#define dictu_instance_h
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+
+bool instanceMethods(char *method, int argCount);
+
+#endif //dictu_instance_h

--- a/docs/docs/classes.md
+++ b/docs/docs/classes.md
@@ -98,6 +98,8 @@ var myObject = Test();
 print(myObject.x); // 10
 ```
 
+### hasAttribute
+
 Attempting to access an attribute of an object that does not exist will throw a runtime error, and instead before accessing, you should check
 if the object has the given attribute. This is done via `hasAttribute`.
 
@@ -113,6 +115,41 @@ print(myObject.hasAttribute("x")); // true
 print(myObject.hasAttribute("y")); // false
 
 print(myObject.z); // Undefined property 'z'.
+```
+
+### getAttribute
+
+Sometimes in Dictu we may wish to access an attribute of an object without knowing the attribute until runtime. We can do this via the `getAttribute` method.
+This method takes a string and an optional default value and returns either the attribute value or the default value (if there is no attribute and no default value, nil is returned).
+
+```js
+class Test {
+    init() {
+        this.x = 10;
+    }
+}
+
+var myObject = Test();
+print(myObject.getAttribute("x")); // 10
+print(myObject.getAttribute("x", 100)); // 10
+print(myObject.getAttribute("y", 100)); // 100
+print(myObject.getAttribute("y")); // nil
+```
+
+### setAttribute
+
+Similar concept to `getAttribute` however this allows us to set an attribute on an instance.
+
+```js
+class Test {
+    init() {
+        this.x = 10;
+    }
+}
+
+var myObject = Test();
+myObject.setAttribute("x", 100);
+print(myObject.x); // 100
 ```
 
 ## Static methods

--- a/tests/classes/properties.du
+++ b/tests/classes/properties.du
@@ -34,3 +34,15 @@ assert(obj.x == 20);
 
 assert(obj.hasAttribute("x"));
 assert(!obj.hasAttribute("y"));
+
+assert(obj.getAttribute("x") == 20);
+assert(obj.getAttribute("x", 50) == 20);
+assert(obj.getAttribute("y", 50) == 50);
+
+obj.setAttribute("y", 10);
+assert(obj.hasAttribute("y"));
+assert(obj.getAttribute("y") == 10);
+
+obj.setAttribute("x", 10);
+assert(obj.hasAttribute("x"));
+assert(obj.getAttribute("x") == 10);


### PR DESCRIPTION
# Instance methods
Resolves #97 
## Summary
This PR adds two new instance methods `getAttribute` and `setAttribute`. These two methods allow attributes to be set / gathered from instances at runtime when the attribute is unknown.

Examples
```js
class Test {
    init() {
        this.x = 10;
    }
}
var myObject = Test();
print(myObject.getAttribute("x")); // 10
print(myObject.getAttribute("x", 100)); // 10
print(myObject.getAttribute("y", 100)); // 100
print(myObject.getAttribute("y")); // nil
```

```js
class Test {
    init() {
        this.x = 10;
    }
}
var myObject = Test();
myObject.setAttribute("x", 100);
print(myObject.x); // 100
```