### PR TITLE
Whole range of cleanup

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -92,6 +92,8 @@ typedef struct Compiler {
     int scopeDepth;
 
     int loopDepth;
+
+    bool repl;
 } Compiler;
 
 typedef struct ClassCompiler {
@@ -242,7 +244,7 @@ static void patchJump(int offset) {
 }
 
 static void initCompiler(Compiler *compiler, int scopeDepth,
-                         FunctionType type) {
+                         FunctionType type, bool repl) {
     compiler->enclosing = current;
     compiler->function = NULL;
     compiler->type = type;
@@ -250,6 +252,7 @@ static void initCompiler(Compiler *compiler, int scopeDepth,
     compiler->scopeDepth = scopeDepth;
     compiler->loopDepth = 0;
     compiler->function = newFunction(type == TYPE_STATIC);
+    compiler->repl = repl;
     current = compiler;
 
     switch (type) {
@@ -1093,7 +1096,6 @@ static void parsePrecedence(Precedence precedence) {
         // If we get here, we didn't parse the "=" even though we could
         // have, so the LHS must not be a valid lvalue.
         error("Invalid assignment target.");
-        expression();
     }
 }
 
@@ -1115,7 +1117,7 @@ static void block() {
 
 static void function(FunctionType type) {
     Compiler compiler;
-    initCompiler(&compiler, 1, type);
+    initCompiler(&compiler, 1, type, current->repl);
 
     // Compile the parameter list.
     consume(TOKEN_LEFT_PAREN, "Expect '(' after function name.");
@@ -1282,7 +1284,11 @@ static void varDeclaration() {
 static void expressionStatement() {
     expression();
     consume(TOKEN_SEMICOLON, "Expect ';' after expression.");
-    emitByte(OP_POP_REPL);
+    if (current->repl) {
+        emitByte(OP_POP_REPL);
+    } else {
+        emitByte(OP_POP);
+    }
 }
 
 /*
@@ -1686,10 +1692,10 @@ static void statement() {
     }
 }
 
-ObjFunction *compile(const char *source) {
+ObjFunction *compile(const char *source, bool repl) {
     initScanner(source);
     Compiler mainCompiler;
-    initCompiler(&mainCompiler, 0, TYPE_TOP_LEVEL);
+    initCompiler(&mainCompiler, 0, TYPE_TOP_LEVEL, repl);
     parser.hadError = false;
     parser.panicMode = false;
 

--- a/c/compiler.h
+++ b/c/compiler.h
@@ -4,7 +4,7 @@
 #include "object.h"
 #include "vm.h"
 
-ObjFunction *compile(const char *source);
+ObjFunction *compile(const char *source, bool repl);
 
 void grayCompilerRoots();
 

--- a/c/memory.c
+++ b/c/memory.c
@@ -71,9 +71,9 @@ void grayObject(Obj *object) {
     if (object->isDark) return;
 
 #ifdef DEBUG_TRACE_GC
-    //printf("%p gray ", (void *)object);
-    //printValue(OBJ_VAL(object));
-    //printf("\n");
+    printf("%p gray ", (void *)object);
+    printValue(OBJ_VAL(object));
+    printf("\n");
 #endif
 
     object->isDark = true;
@@ -103,9 +103,9 @@ static void grayArray(ValueArray *array) {
 
 static void blackenObject(Obj *object) {
 #ifdef DEBUG_TRACE_GC
-    //printf("%p blacken ", (void *)object);
-    //printValue(OBJ_VAL(object));
-    //printf("\n");
+    printf("%p blacken ", (void *)object);
+    printValue(OBJ_VAL(object));
+    printf("\n");
 #endif
 
     switch (object->type) {
@@ -197,9 +197,7 @@ static void blackenObject(Obj *object) {
 
 void freeObject(Obj *object) {
 #ifdef DEBUG_TRACE_GC
-    //printf("%p free ", (void *)object);
-    //printValue(OBJ_VAL(object));
-    //printf("\n");
+    printf("%p free type %d\n", (void*)object, object->type);
 #endif
 
     switch (object->type) {
@@ -224,7 +222,7 @@ void freeObject(Obj *object) {
 
         case OBJ_CLOSURE: {
             ObjClosure *closure = (ObjClosure *) object;
-            FREE_ARRAY(ObjClosure, closure->upvalues, closure->upvalueCount);
+            FREE_ARRAY(Value*, closure->upvalues, closure->upvalueCount);
             FREE(ObjClosure, object);
             break;
         }

--- a/c/value.h
+++ b/c/value.h
@@ -27,7 +27,7 @@ typedef struct sObjFile ObjFile;
 
 typedef uint64_t Value;
 
-#define IS_BOOL(v)    (((v) & (QNAN | TAG_FALSE)) == (QNAN | TAG_FALSE))
+#define IS_BOOL(v)    (((v) & FALSE_VAL) == FALSE_VAL)
 #define IS_NIL(v)     ((v) == NIL_VAL)
 // If the NaN bits are set, it's not a number.
 #define IS_NUMBER(v)  (((v) & QNAN) != QNAN)

--- a/c/vm.c
+++ b/c/vm.c
@@ -266,7 +266,7 @@ static bool invoke(ObjString *name, int argCount) {
             Value value;
             // First look for a field which may shadow a method.
             if (tableGet(&instance->fields, name, &value)) {
-                vm.stackTop[-argCount] = value;
+                vm.stackTop[-argCount - 1] = value;
                 return callValue(value, argCount);
             }
 
@@ -520,15 +520,11 @@ static InterpretResult run() {
             DISPATCH();
 
         CASE_CODE(POP_REPL): {
-            if (vm.repl) {
-                Value v = pop();
-                if (!IS_NIL(v)) {
-                    setReplVar(v);
-                    printValue(v);
-                    printf("\n");
-                }
-            } else {
-                pop();
+            Value v = pop();
+            if (!IS_NIL(v)) {
+                setReplVar(v);
+                printValue(v);
+                printf("\n");
             }
             DISPATCH();
         }
@@ -823,7 +819,7 @@ static InterpretResult run() {
             char *s = readFile(fileName->chars);
             vm.currentScriptName = fileName->chars;
 
-            ObjFunction *function = compile(s);
+            ObjFunction *function = compile(s, vm.repl);
             if (function == NULL) return INTERPRET_COMPILE_ERROR;
             push(OBJ_VAL(function));
             ObjClosure *closure = newClosure(function);
@@ -1394,7 +1390,7 @@ void initArgv(int argc, const char *argv[]) {
 }
 
 InterpretResult interpret(const char *source, int argc, const char *argv[]) {
-    ObjFunction *function = compile(source);
+    ObjFunction *function = compile(source, vm.repl);
     if (function == NULL) return INTERPRET_COMPILE_ERROR;
     push(OBJ_VAL(function));
     ObjClosure *closure = newClosure(function);


### PR DESCRIPTION
# Cleanup
## Summary
- Add "repl" condition to compiler to decide OP_POP(_REPL) rather than in the VM
- Remove unnecessary expression() call
- Add prints back to debug GC trace
- Simplify `IS_BOOL` macro
- Fix instance call