### PR TITLE
Change tabs in the REPL to be 4 spaces

### DIFF
--- a/c/linenoise.h
+++ b/c/linenoise.h
@@ -39,6 +39,8 @@
 #ifndef __LINENOISE_H
 #define __LINENOISE_H
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
# REPL
Resolves #118 
## Summary
This PR changes how tabs work within the REPL. Currently (as shown in the issue) linenoise doesn't seem to work with tabs very well, and seems to give weird behaviour. To counter this this PR converts tabs to 4 spaces and outputs those instead of the tab character.