### PR TITLE
Fix segfault when GC stress is enabled

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -96,7 +96,7 @@ static void repl(int argc, const char *argv[]) {
             linenoiseHistorySave("history.txt");
         }
 
-        interpret(fullLine, argc, argv);
+        interpret(fullLine);
 
         free(line);
         free(fullLine);
@@ -105,7 +105,7 @@ static void repl(int argc, const char *argv[]) {
 
 static void runFile(int argc, const char *argv[]) {
     char *source = readFile(argv[1]);
-    InterpretResult result = interpret(source, argc, argv);
+    InterpretResult result = interpret(source);
     free(source); // [owner]
 
     if (result == INTERPRET_COMPILE_ERROR) exit(65);
@@ -113,7 +113,7 @@ static void runFile(int argc, const char *argv[]) {
 }
 
 int main(int argc, const char *argv[]) {
-    initVM(argc == 1, argc >= 2 ? argv[1] : "repl");
+    initVM(argc == 1, argc >= 2 ? argv[1] : "repl", argc, argv);
 
     if (argc == 1) {
         repl(argc, argv);

--- a/c/vm.c
+++ b/c/vm.c
@@ -79,8 +79,8 @@ void initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
     vm.objects = NULL;
     vm.repl = repl;
     vm.gc = true;
-    vm.scriptName = argv[1];
-    vm.currentScriptName = argv[1];
+    vm.scriptName = scriptName;
+    vm.currentScriptName = scriptName;
     vm.frameCapacity = 4;
     vm.frames = realloc(NULL, sizeof(CallFrame) * 4);
     vm.bytesAllocated = 0;

--- a/c/vm.h
+++ b/c/vm.h
@@ -48,11 +48,11 @@ typedef enum {
 
 extern VM vm;
 
-void initVM(bool repl, const char *scriptName);
+void initVM(bool repl, const char *scriptName, int argc, const char *argv[]);
 
 void freeVM();
 
-InterpretResult interpret(const char *source, int argc, const char *argv[]);
+InterpretResult interpret(const char *source);
 
 void push(Value value);
 


### PR DESCRIPTION
# Fix segfault
Resolves #121 
## Summary
This PR moves when argv is defined from `interpret` to `initVM` as the argv was causing a segfault due to the GC.
