### PR TITLE
Rework natives

### DIFF
--- a/c/memory.c
+++ b/c/memory.c
@@ -195,7 +195,6 @@ static void blackenObject(Obj *object) {
 
 
         case OBJ_NATIVE:
-        case OBJ_NATIVE_VOID:
         case OBJ_STRING:
         case OBJ_FILE:
             break;
@@ -257,11 +256,6 @@ void freeObject(Obj *object) {
 
         case OBJ_NATIVE: {
             FREE(ObjNative, object);
-            break;
-        }
-
-        case OBJ_NATIVE_VOID: {
-            FREE(ObjNativeVoid, object);
             break;
         }
 

--- a/c/object.c
+++ b/c/object.c
@@ -96,12 +96,6 @@ ObjNative *newNative(NativeFn function) {
     return native;
 }
 
-ObjNativeVoid *newNativeVoid(NativeFnVoid function) {
-    ObjNativeVoid *native = ALLOCATE_OBJ(ObjNativeVoid, OBJ_NATIVE_VOID);
-    native->function = function;
-    return native;
-}
-
 static ObjString *allocateString(char *chars, int length,
                                  uint32_t hash) {
     ObjString *string = ALLOCATE_OBJ(ObjString, OBJ_STRING);
@@ -253,7 +247,6 @@ char *objectToString(Value value) {
             return instanceString;
         }
 
-        case OBJ_NATIVE_VOID:
         case OBJ_NATIVE: {
             char *nativeString = malloc(sizeof(char) * 12);
             snprintf(nativeString, 12, "%s", "<native fn>");

--- a/c/object.h
+++ b/c/object.h
@@ -19,7 +19,6 @@
 #define IS_FUNCTION(value)      isObjType(value, OBJ_FUNCTION)
 #define IS_INSTANCE(value)      isObjType(value, OBJ_INSTANCE)
 #define IS_NATIVE(value)        isObjType(value, OBJ_NATIVE)
-#define IS_NATIVE_VOID(value)   isObjType(value, OBJ_NATIVE_VOID)
 #define IS_STRING(value)        isObjType(value, OBJ_STRING)
 #define IS_LIST(value)          isObjType(value, OBJ_LIST)
 #define IS_DICT(value)          isObjType(value, OBJ_DICT)
@@ -34,7 +33,6 @@
 #define AS_FUNCTION(value)      ((ObjFunction*)AS_OBJ(value))
 #define AS_INSTANCE(value)      ((ObjInstance*)AS_OBJ(value))
 #define AS_NATIVE(value)        (((ObjNative*)AS_OBJ(value))->function)
-#define AS_NATIVE_VOID(value)   (((ObjNativeVoid*)AS_OBJ(value))->function)
 #define AS_STRING(value)        ((ObjString*)AS_OBJ(value))
 #define AS_CSTRING(value)       (((ObjString*)AS_OBJ(value))->chars)
 #define AS_LIST(value)          ((ObjList*)AS_OBJ(value))
@@ -51,7 +49,6 @@ typedef enum {
     OBJ_FUNCTION,
     OBJ_INSTANCE,
     OBJ_NATIVE,
-    OBJ_NATIVE_VOID,
     OBJ_STRING,
     OBJ_LIST,
     OBJ_DICT,
@@ -84,11 +81,6 @@ typedef struct {
     Obj obj;
     NativeFn function;
 } ObjNative;
-
-typedef struct {
-    Obj obj;
-    NativeFnVoid function;
-} ObjNativeVoid;
 
 struct sObjString {
     Obj obj;
@@ -206,8 +198,6 @@ ObjFunction *newFunction(bool isStatic);
 ObjInstance *newInstance(ObjClass *klass);
 
 ObjNative *newNative(NativeFn function);
-
-ObjNativeVoid *newNativeVoid(NativeFnVoid function);
 
 ObjString *takeString(char *chars, int length);
 

--- a/c/optionals/env.c
+++ b/c/optionals/env.c
@@ -1,0 +1,60 @@
+#include "env.h"
+
+static Value get(int argCount, Value *args) {
+    if (argCount != 1) {
+        runtimeError("get() takes 1 argument (%d given).", argCount);
+        return EMPTY_VAL;
+    }
+
+    if (!IS_STRING(args[0])) {
+        runtimeError("get() argument must be a string.");
+        return EMPTY_VAL;
+    }
+
+    char *value = getenv(AS_CSTRING(args[0]));
+
+    if (value != NULL) {
+        return OBJ_VAL(copyString(value, strlen(value)));
+    }
+
+    return NIL_VAL;
+}
+
+static Value set(int argCount, Value *args) {
+    if (argCount != 2) {
+        runtimeError("set() takes 2 arguments (%d given).", argCount);
+        return EMPTY_VAL;
+    }
+
+    if (!IS_STRING(args[0]) || (!IS_STRING(args[1]) && !IS_NIL(args[1]))) {
+        runtimeError("set() arguments must be a string or nil.");
+        return EMPTY_VAL;
+    }
+
+    char *key = AS_CSTRING(args[0]);
+
+    if (IS_NIL(args[1])) {
+        unsetenv(key);
+    } else {
+        setenv(key, AS_CSTRING(args[1]), 1);
+    }
+
+    return NIL_VAL;
+}
+
+void createEnvClass() {
+    ObjString *name = copyString("Env", 3);
+    push(OBJ_VAL(name));
+    ObjClassNative *klass = newClassNative(name);
+    push(OBJ_VAL(klass));
+
+    /**
+     * Define Env methods
+     */
+    defineNativeMethod(klass, "get", get);
+    defineNativeMethod(klass, "set", set);
+
+    tableSet(&vm.globals, name, OBJ_VAL(klass));
+    pop();
+    pop();
+}

--- a/c/optionals/env.h
+++ b/c/optionals/env.h
@@ -1,0 +1,12 @@
+#ifndef dictu_env_h
+#define dictu_env_h
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "optionals.h"
+#include "../vm.h"
+
+void createEnvClass();
+
+#endif //dictu_env_h

--- a/c/optionals/math.c
+++ b/c/optionals/math.c
@@ -17,7 +17,7 @@ static Value averageNative(int argCount, Value *args) {
         Value value = args[i];
         if (!IS_NUMBER(value)) {
             runtimeError("A non-number value passed to average()");
-            return NIL_VAL;
+            return EMPTY_VAL;
         }
         average = average + AS_NUMBER(value);
     }
@@ -28,12 +28,12 @@ static Value averageNative(int argCount, Value *args) {
 static Value floorNative(int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError("floor() takes 1 argument (%d given).", argCount);
-        return NIL_VAL;
+        return EMPTY_VAL;
     }
 
     if (!IS_NUMBER(args[0])) {
         runtimeError("A non-number value passed to floor()");
-        return NIL_VAL;
+        return EMPTY_VAL;
     }
 
 
@@ -43,12 +43,12 @@ static Value floorNative(int argCount, Value *args) {
 static Value roundNative(int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError("round() takes 1 argument (%d given).", argCount);
-        return NIL_VAL;
+        return EMPTY_VAL;
     }
 
     if (!IS_NUMBER(args[0])) {
         runtimeError("A non-number value passed to round()");
-        return NIL_VAL;
+        return EMPTY_VAL;
     }
 
 
@@ -58,12 +58,12 @@ static Value roundNative(int argCount, Value *args) {
 static Value ceilNative(int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError("ceil() takes 1 argument (%d given).", argCount);
-        return NIL_VAL;
+        return EMPTY_VAL;
     }
 
     if (!IS_NUMBER(args[0])) {
         runtimeError("A non-number value passed to ceil()");
-        return NIL_VAL;
+        return EMPTY_VAL;
     }
 
 
@@ -73,12 +73,12 @@ static Value ceilNative(int argCount, Value *args) {
 static Value absNative(int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError("abs() takes 1 argument (%d given).", argCount);
-        return NIL_VAL;
+        return EMPTY_VAL;
     }
 
     if (!IS_NUMBER(args[0])) {
         runtimeError("A non-number value passed to abs()");
-        return NIL_VAL;
+        return EMPTY_VAL;
     }
 
     double absValue = AS_NUMBER(args[0]);
@@ -103,7 +103,7 @@ static Value sumNative(int argCount, Value *args) {
         Value value = args[i];
         if (!IS_NUMBER(value)) {
             runtimeError("A non-number value passed to sum()");
-            return NIL_VAL;
+            return EMPTY_VAL;
         }
         sum = sum + AS_NUMBER(value);
     }
@@ -126,7 +126,7 @@ static Value minNative(int argCount, Value *args) {
         Value value = args[i];
         if (!IS_NUMBER(value)) {
             runtimeError("A non-number value passed to min()");
-            return NIL_VAL;
+            return EMPTY_VAL;
         }
 
         double current = AS_NUMBER(value);
@@ -154,7 +154,7 @@ static Value maxNative(int argCount, Value *args) {
         Value value = args[i];
         if (!IS_NUMBER(value)) {
             runtimeError("A non-number value passed to max()");
-            return NIL_VAL;
+            return EMPTY_VAL;
         }
 
         double current = AS_NUMBER(value);

--- a/c/optionals/optionals.h
+++ b/c/optionals/optionals.h
@@ -2,8 +2,11 @@
 #define dictu_optionals_h
 
 #include "math.h"
+#include "env.h"
 #include "../vm.h"
 
 void defineNativeMethod(ObjClassNative *klass, const char *name, NativeFn function);
+
+void defineNativeVoidMethod(ObjClassNative *klass, const char *name, NativeFnVoid function);
 
 #endif //dictu_optionals_h

--- a/c/value.h
+++ b/c/value.h
@@ -21,14 +21,16 @@ typedef struct sObjFile ObjFile;
 #define QNAN ((uint64_t)0x7ffc000000000000)
 
 // Tag values for the different singleton values.
-#define TAG_NIL   1 // 01
-#define TAG_FALSE 2 // 10
-#define TAG_TRUE  3 // 11
+#define TAG_NIL    1
+#define TAG_FALSE  2
+#define TAG_TRUE   3
+#define TAG_EMPTY  4
 
 typedef uint64_t Value;
 
 #define IS_BOOL(v)    (((v) & FALSE_VAL) == FALSE_VAL)
 #define IS_NIL(v)     ((v) == NIL_VAL)
+#define IS_EMPTY(v)   ((v) == EMPTY_VAL)
 // If the NaN bits are set, it's not a number.
 #define IS_NUMBER(v)  (((v) & QNAN) != QNAN)
 #define IS_OBJ(v)     (((v) & (QNAN | SIGN_BIT)) == (QNAN | SIGN_BIT))
@@ -37,10 +39,11 @@ typedef uint64_t Value;
 #define AS_NUMBER(v)  valueToNum(v)
 #define AS_OBJ(v)     ((Obj*)(uintptr_t)((v) & ~(SIGN_BIT | QNAN)))
 
-#define BOOL_VAL(boolean) ((boolean) ? TRUE_VAL : FALSE_VAL)
-#define FALSE_VAL         ((Value)(uint64_t)(QNAN | TAG_FALSE))
-#define TRUE_VAL          ((Value)(uint64_t)(QNAN | TAG_TRUE))
-#define NIL_VAL           ((Value)(uint64_t)(QNAN | TAG_NIL))
+#define BOOL_VAL(boolean)   ((boolean) ? TRUE_VAL : FALSE_VAL)
+#define FALSE_VAL           ((Value)(uint64_t)(QNAN | TAG_FALSE))
+#define TRUE_VAL            ((Value)(uint64_t)(QNAN | TAG_TRUE))
+#define NIL_VAL             ((Value)(uint64_t)(QNAN | TAG_NIL))
+#define EMPTY_VAL           ((Value)(uint64_t)(QNAN | TAG_EMPTY))
 #define NUMBER_VAL(num)   numToValue(num)
 // The triple casting is necessary here to satisfy some compilers:
 // 1. (uintptr_t) Convert the pointer to a number of the right size.

--- a/c/vm.c
+++ b/c/vm.c
@@ -96,6 +96,7 @@ void initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
     vm.replVar = copyString("_", 1);
     defineAllNatives();
     createMathsClass();
+    createEnvClass();
 
     if (!vm.repl) {
         initArgv(argc, argv);
@@ -189,22 +190,11 @@ static bool callValue(Value callee, int argCount) {
             case OBJ_CLOSURE:
                 return call(AS_CLOSURE(callee), argCount);
 
-            case OBJ_NATIVE_VOID: {
-                NativeFnVoid native = AS_NATIVE_VOID(callee);
-                if (!native(argCount, vm.stackTop - argCount))
-                    return false;
-
-                vm.stackTop -= argCount + 1;
-                vm.stackCount -= argCount + 1;
-                push(NIL_VAL);
-                return true;
-            }
-
             case OBJ_NATIVE: {
                 NativeFn native = AS_NATIVE(callee);
                 Value result = native(argCount, vm.stackTop - argCount);
 
-                if (IS_NIL(result))
+                if (IS_EMPTY(result))
                     return false;
 
                 vm.stackTop -= argCount + 1;

--- a/docs/docs/env.md
+++ b/docs/docs/env.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: Env
+nav_order: 12
+---
+
+# Env
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+### Access ENV vars
+
+You can access ENV vars through the use of the Env.get() method. If the ENV var does not exist nil is returned, other wise
+a string value is returned.
+
+```
+Env.get("bad key!"); // nil
+Env.get("valid key"); // "value"
+```
+
+### Setting ENV vars
+
+You can set ENV vars through the use of the Env.set() method. You can also clear an ENV var by passing a `nil` value.
+When setting an ENV var the key must be a string and the value must be either a string or nil;
+
+```
+Env.set("key", "test");
+Env.set("key", nil); // Remove env var
+Env.set("key", 10); // set() arguments must be a string or nil.
+```

--- a/tests/env/env.du
+++ b/tests/env/env.du
@@ -1,0 +1,13 @@
+/**
+ * end.du
+ *
+ * Testing the Env functions:
+ *    - get(), set()
+ *
+ */
+
+assert(Env.get("bad key") == nil);
+Env.set("test", "test");
+assert(Env.get("test") == "test");
+Env.set("test", nil);
+assert(Env.get("test") == nil);

--- a/tests/env/import.du
+++ b/tests/env/import.du
@@ -1,0 +1,7 @@
+/**
+ * import.du
+ *
+ * General import file for all the Env methods
+ */
+
+import "tests/env/env.du";

--- a/tests/maths/maths.du
+++ b/tests/maths/maths.du
@@ -1,7 +1,7 @@
 /**
 * maths.du
 *
-* Testing the builtin maths functions:
+* Testing the Math functions:
 *    - min(), max(), average(), sum(), floor(), round(), ceil(), abs()
 *
 */

--- a/tests/runTests.du
+++ b/tests/runTests.du
@@ -9,6 +9,7 @@ import "tests/classes/import.du";
 import "tests/builtins/import.du";
 import "tests/maths/import.du";
 import "tests/loops/import.du";
+import "tests/env/import.du";
 
 // If we got here no runtime errors were thrown, therefore all tests passed.
 print("All tests passed successfully!");


### PR DESCRIPTION
# Rework Natives
## Summary
Currently when defining a native there is two routes a function can take, either `defineNative` or `defineNativeVoid` where the first returns a `Value` and the latter returns a Boolean. Instead this PR removes the need for this duplication and instead of returning and checking for errors on `NIL_VAL` there is a new `EMPTY_VAL` which has a sole purpose of error checking.
This PR also adds a new `Env` class which allows getting and setting of ENV vars. 