### PR TITLE
Fix snprintf length

### DIFF
--- a/c/value.c
+++ b/c/value.c
@@ -286,7 +286,7 @@ char *valueToString(Value value) {
     }
 
     char *unknown = malloc(sizeof(char) * 8);
-    snprintf(unknown, 7, "%s", "unknown");
+    snprintf(unknown, 8, "%s", "unknown");
     return unknown;
 }
 


### PR DESCRIPTION
# Fix snprintf length
Resolves #128 
## Summary
The length being passed to snprintf for the "unknown" string is 7 and should be 8.