### PR TITLE
Fix memory leak in list.join()

### DIFF
--- a/c/datatypes/lists.c
+++ b/c/datatypes/lists.c
@@ -191,9 +191,10 @@ static bool joinListItem(int argCount) {
     fullString[index] = '\0';
     push(OBJ_VAL(copyString(fullString, index)));
 
-    if (!IS_STRING(list->values.values[j])) {
+    if (!IS_STRING(list->values.values[list->values.count - 1])) {
         free(output);
     }
+    free(fullString);
 
     return true;
 }

--- a/c/datatypes/lists.c
+++ b/c/datatypes/lists.c
@@ -191,6 +191,10 @@ static bool joinListItem(int argCount) {
     fullString[index] = '\0';
     push(OBJ_VAL(copyString(fullString, index)));
 
+    if (!IS_STRING(list->values.values[j])) {
+        free(output);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
# Fix memory leak
## Summary
In the list.join() method, some allocated memory was not being free'd as it should have been, this PR addresses this.