### PR TITLE
Add System.getcwd()

### DIFF
--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -68,7 +68,7 @@ void createSystemClass() {
     /**
      * Define System methods
      */
-    defineNativeMethod(klass, "getcwd", getCWDNative);
+    defineNativeMethod(klass, "getCWD", getCWDNative);
     defineNativeMethod(klass, "time", timeNative);
     defineNativeMethod(klass, "clock", clockNative);
     defineNativeMethod(klass, "collect", collectNative);

--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -1,5 +1,16 @@
 #include "system.h"
 
+static Value getCWDNative(int argCount, Value *args) {
+    char cwd[PATH_MAX];
+
+    if (getcwd(cwd, sizeof(cwd)) != NULL) {
+        return OBJ_VAL(copyString(cwd, strlen(cwd)));
+    }
+
+    runtimeError("Error getting current directory");
+    return EMPTY_VAL;
+}
+
 static Value timeNative(int argCount, Value *args) {
     return NUMBER_VAL((double) time(NULL));
 }
@@ -57,6 +68,7 @@ void createSystemClass() {
     /**
      * Define System methods
      */
+    defineNativeMethod(klass, "getcwd", getCWDNative);
     defineNativeMethod(klass, "time", timeNative);
     defineNativeMethod(klass, "clock", clockNative);
     defineNativeMethod(klass, "collect", collectNative);

--- a/c/optionals/system.h
+++ b/c/optionals/system.h
@@ -2,6 +2,8 @@
 #define dictu_system_h
 
 #include <time.h>
+#include <unistd.h>
+#include <limits.h>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/docs/docs/system.md
+++ b/docs/docs/system.md
@@ -15,6 +15,14 @@ nav_order: 13
 
 ---
 
+### System.getcwd()
+
+Get current working directory of the Dictu process returned as a string
+
+```js
+System.getcwd(); // '/Some/Path/To/A/Directory'
+```
+
 ### System.sleep(number)
 
 Sleep pauses execution of the program for a given amount of time in seconds

--- a/docs/docs/system.md
+++ b/docs/docs/system.md
@@ -15,12 +15,12 @@ nav_order: 13
 
 ---
 
-### System.getcwd()
+### System.getCWD()
 
 Get current working directory of the Dictu process returned as a string
 
 ```js
-System.getcwd(); // '/Some/Path/To/A/Directory'
+System.getCWD(); // '/Some/Path/To/A/Directory'
 ```
 
 ### System.sleep(number)

--- a/tests/system/clock.du
+++ b/tests/system/clock.du
@@ -1,0 +1,14 @@
+/**
+ * clock.du
+ *
+ * Testing the System.clock() function
+ *
+ * clock() returns number of clock ticks since the start of the program, useful for benchmarks.
+ */
+
+assert(type(System.clock()) == 'number');
+assert(System.clock() > 0);
+
+var x = System.clock();
+
+assert(System.clock() > x);

--- a/tests/system/clock.du
+++ b/tests/system/clock.du
@@ -11,4 +11,6 @@ assert(System.clock() > 0);
 
 var x = System.clock();
 
+System.sleep(1);
+
 assert(System.clock() > x);

--- a/tests/system/getCWD.du
+++ b/tests/system/getCWD.du
@@ -1,0 +1,10 @@
+/**
+ * getCWD.du
+ *
+ * Testing the System.getCWD() function
+ *
+ * getCWD() gets the current working directory of the process
+ */
+
+assert(type(System.getCWD()) == 'string');
+assert(len(System.getCWD()) > 0);

--- a/tests/system/import.du
+++ b/tests/system/import.du
@@ -5,3 +5,4 @@
  */
 
 import "tests/system/sleep.du";
+import "tests/system/getCWD.du";

--- a/tests/system/import.du
+++ b/tests/system/import.du
@@ -6,3 +6,5 @@
 
 import "tests/system/sleep.du";
 import "tests/system/getCWD.du";
+import "tests/system/clock.du";
+import "tests/system/time.du";

--- a/tests/system/time.du
+++ b/tests/system/time.du
@@ -1,0 +1,14 @@
+/**
+ * clock.du
+ *
+ * Testing the System.time() function
+ *
+ * clock() returns a UNIX timestamp.
+ */
+
+assert(type(System.time()) == 'number');
+assert(System.time() > 0);
+
+var x = System.time();
+
+assert(System.time() > x);

--- a/tests/system/time.du
+++ b/tests/system/time.du
@@ -6,9 +6,7 @@
  * clock() returns a UNIX timestamp.
  */
 
+// Time is also tested within sleep.du
+
 assert(type(System.time()) == 'number');
 assert(System.time() > 0);
-
-var x = System.time();
-
-assert(System.time() > x);


### PR DESCRIPTION
# System.getcwd()
Resolves #135 
## Summary
This PR adds the ability to get the current working directory of the Dictu process. This PR adds a new method to the `System` native.
### Examples
```
System.getcwd(); // '/path/here/to/a/directory'
```