### PR TITLE
GC

### DIFF
--- a/c/datatypes/copy.c
+++ b/c/datatypes/copy.c
@@ -13,10 +13,9 @@ uint32_t hash(char *str) {
 ObjList *copyList(ObjList *oldList, bool shallow);
 
 ObjDict *copyDict(ObjDict *oldDict, bool shallow) {
-    // Ensure the GC does *not* run while we are creating the list
-    vm.gc = false;
-
     ObjDict *newDict = initDict();
+    // Push to stack to avoid GC
+    push(OBJ_VAL(newDict));
 
     for (int i = 0; i < oldDict->capacity; ++i) {
         if (oldDict->items[i] == NULL) {
@@ -33,66 +32,20 @@ ObjDict *copyDict(ObjDict *oldDict, bool shallow) {
             }
         }
 
-        ObjDict *dict = newDict;
-        char *key = oldDict->items[i]->key;
-
-        if (dict->count * 100 / dict->capacity >= 60) {
-            resizeDict(dict, true);
-        }
-
-        uint32_t hashValue = hash(key);
-        int index = hashValue % dict->capacity;
-
-        size_t keySize = sizeof(char) * (strlen(key) + 1);
-        char *key_m = realloc(NULL, keySize);
-        vm.bytesAllocated += keySize;
-
-        if (key_m == NULL) {
-            printf("Unable to allocate memory\n");
-            exit(71);
-        }
-
-        strcpy(key_m, key);
-        size_t dictSize = sizeof(dictItem) * (sizeof(dictItem));
-        dictItem *item = realloc(NULL, dictSize);
-        vm.bytesAllocated += dictSize;
-
-        if (item == NULL) {
-            printf("Unable to allocate memory\n");
-            exit(71);
-        }
-
-        item->key = key_m;
-        item->item = val;
-        item->deleted = false;
-        item->hash = hashValue;
-
-        while (dict->items[index] && !dict->items[index]->deleted && strcmp(dict->items[index]->key, key) != 0) {
-            index++;
-            if (index == dict->capacity) {
-                index = 0;
-            }
-        }
-
-        if (dict->items[index]) {
-            free(dict->items[index]->key);
-            free(dict->items[index]);
-            dict->count--;
-        }
-
-        dict->items[index] = item;
-        dict->count++;
+        // Push to stack to avoid GC
+        push(val);
+        insertDict(newDict, oldDict->items[i]->key, val);
+        pop();
     }
 
-    vm.gc = true;
+    pop();
     return newDict;
 }
 
 ObjList *copyList(ObjList *oldList, bool shallow) {
-    // Ensure the GC does *not* run while we are creating the list
-    vm.gc = false;
-
     ObjList *newList = initList();
+    // Push to stack to avoid GC
+    push(OBJ_VAL(newList));
 
     for (int i = 0; i < oldList->values.count; ++i) {
         Value val = oldList->values.values[i];
@@ -105,20 +58,13 @@ ObjList *copyList(ObjList *oldList, bool shallow) {
             }
         }
 
-        ValueArray *array = &newList->values;
-
-        if (array->capacity < array->count + 1) {
-            int oldCapacity = array->capacity;
-            array->capacity = GROW_CAPACITY(oldCapacity);
-            vm.bytesAllocated += sizeof(Value) * (array->capacity) - sizeof(Value) * (oldCapacity);
-            array->values = realloc(array->values, sizeof(Value) * (array->capacity));
-        }
-
-        array->values[array->count] = val;
-        array->count++;
+        // Push to stack to avoid GC
+        push(val);
+        writeValueArray(&newList->values, val);
+        pop();
     }
 
-    vm.gc = true;
+    pop();
     return newList;
 }
 

--- a/c/datatypes/instance.c
+++ b/c/datatypes/instance.c
@@ -88,6 +88,8 @@ bool instanceMethods(char *method, int argCount) {
         return getAttribute(argCount);
     } else if (strcmp(method, "setAttribute") == 0) {
         return setAttribute(argCount);
+    } else if (false) {
+
     }
 
     return false;

--- a/c/memory.c
+++ b/c/memory.c
@@ -298,10 +298,6 @@ void freeObject(Obj *object) {
 }
 
 void collectGarbage() {
-    if (!vm.gc) {
-        return;
-    }
-
 #ifdef DEBUG_TRACE_GC
     printf("-- gc begin\n");
     size_t before = vm.bytesAllocated;

--- a/c/vm.c
+++ b/c/vm.c
@@ -79,7 +79,6 @@ void initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
     resetStack();
     vm.objects = NULL;
     vm.repl = repl;
-    vm.gc = true;
     vm.scriptName = scriptName;
     vm.currentScriptName = scriptName;
     vm.frameCapacity = 4;
@@ -113,7 +112,6 @@ void freeVM() {
     FREE_ARRAY(CallFrame, vm.frames, vm.frameCapacity);
     vm.initString = NULL;
     vm.replVar = NULL;
-    vm.gc = NULL;
     freeObjects();
 }
 


### PR DESCRIPTION
# Summary
Currently some of the methods are using a boolean on the VM to know when to skip calls to `collectGarbage`. This is kind of a workaround and not the "proper" way to do it. This PR removes this workaround. Instead, values are pushed onto the stack so there is still a "reference" and popped when they can be. This makes most of the methods a lot simpler due to the fact memory allocation can be done the same way rather than having to side step the GC.