### PR TITLE
Silence tcc compiler and add a return statement to exitNative().

### DIFF
--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -57,6 +57,8 @@ static Value exitNative(int argCount, Value *args) {
     }
 
     exit(AS_NUMBER(args[0]));
+    return EMPTY_VAL; /* satisfy the tcc compiler */
+
 }
 
 void createSystemClass() {


### PR DESCRIPTION
This allows Dictu to build by the tcc (tinycc) compiler.