### PR TITLE
Make building the http class optional, as it requires libcurl (for no…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Make dictu and run tests
+      - name: Make dictu and run tests (No HTTP)
+          run: |
+            make debug DISABLE_HTTP=1
+            ./dictu tests/runTests.du
+      - name: Make dictu and run tests (HTTP)
         run: |
           sudo apt-get install -y libcurl4-openssl-dev
           make debug
@@ -30,6 +34,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - name: Make dictu and run tests (No HTTP)
+          run: |
+            make debug DISABLE_HTTP=1
+            ./dictu tests/runTests.du
       - name: Make dictu and run tests
         run: |
           make debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,10 @@ jobs:
       - name: Make dictu and run tests (No HTTP)
         run: |
           make debug DISABLE_HTTP=1
-          ./dictu tests/runTests.du
+          ./dictu tests/runTests.du --disable-http
+      - name: Remove build directory
+        run: |
+          rm -rf build
       - name: Make dictu and run tests (HTTP)
         run: |
           sudo apt-get install -y libcurl4-openssl-dev
@@ -37,7 +40,10 @@ jobs:
       - name: Make dictu and run tests (No HTTP)
         run: |
           make debug DISABLE_HTTP=1
-          ./dictu tests/runTests.du
+          ./dictu tests/runTests.du --disable-http
+      - name: Remove build directory
+        run: |
+          rm -rf build
       - name: Make dictu and run tests
         run: |
           make debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Make dictu and run tests (No HTTP)
-          run: |
-            make debug DISABLE_HTTP=1
-            ./dictu tests/runTests.du
+        run: |
+          make debug DISABLE_HTTP=1
+          ./dictu tests/runTests.du
       - name: Make dictu and run tests (HTTP)
         run: |
           sudo apt-get install -y libcurl4-openssl-dev
@@ -35,9 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Make dictu and run tests (No HTTP)
-          run: |
-            make debug DISABLE_HTTP=1
-            ./dictu tests/runTests.du
+        run: |
+          make debug DISABLE_HTTP=1
+          ./dictu tests/runTests.du
       - name: Make dictu and run tests
         run: |
           make debug

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ $ make dictu
 $ ./dictu examples/guessingGame.du
 ```
 
+### Compiling without HTTP
+
+The HTTP class within Dictu requires [cURL](https://curl.haxx.se/) to be installed when building the interpreter. If you wish to
+build Dictu without cURL, and in turn the HTTP class, build with the `DISABLE_HTTP` flag.
+
+```bash
+$ git clone https://github.com/Jason2605/Dictu.git
+$ cd Dictu
+$ make dictu DISABLE_HTTP=1
+$ ./dictu examples/guessingGame.du
+```
+
 ## Example program
 ```js
 def guessingGame() {

--- a/c.make
+++ b/c.make
@@ -6,7 +6,12 @@
 # SOURCE_DIR   Directory where source files and headers are found.
 
 CFLAGS := -Wall -Wextra -Werror -Wno-unused-parameter -fno-strict-aliasing
-LFLAGS := -lm -lcurl
+LFLAGS := -lm
+
+DISABLE_HTTP := 0
+ifeq ($(DISABLE_HTTP), 0)
+  LFLAGS += -lcurl
+endif
 
 # Mode configuration.
 ifeq ($(MODE),debug)
@@ -20,8 +25,14 @@ endif
 # Files.
 HEADERS := $(wildcard $(SOURCE_DIR)/*.h) $(wildcard $(SOURCE_DIR)/datatypes/*.h) $(wildcard $(SOURCE_DIR)/optionals/*.h)
 SOURCES := $(wildcard $(SOURCE_DIR)/*.c) $(wildcard $(SOURCE_DIR)/datatypes/*.c) $(wildcard $(SOURCE_DIR)/optionals/*.c)
-OBJECTS := $(addprefix $(BUILD_DIR)/$(NAME)/, $(notdir $(SOURCES:.c=.o)))
 
+ifeq ($(DISABLE_HTTP), 1)
+    CFLAGS  += -DDISABLE_HTTP
+    SOURCES := $(filter-out %http.c, $(SOURCES))
+    HEADERS := $(filter-out %http.h, $(HEADERS))
+endif
+
+OBJECTS := $(addprefix $(BUILD_DIR)/$(NAME)/, $(notdir $(SOURCES:.c=.o)))
 # Targets ---------------------------------------------------------------------
 
 # Link the interpreter.

--- a/c/optionals/http.h
+++ b/c/optionals/http.h
@@ -1,7 +1,9 @@
 #ifndef dictu_http_h
 #define dictu_http_h
 
+#ifndef DISABLE_HTTP
 #include <curl/curl.h>
+#endif
 
 #include "optionals.h"
 #include "../vm.h"

--- a/c/vm.c
+++ b/c/vm.c
@@ -98,7 +98,9 @@ void initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
     createEnvClass();
     createSystemClass();
     createJSONClass();
+#ifndef DISABLE_HTTP
     createHTTPClass();
+#endif
 
     if (!vm.repl) {
         initArgv(argc, argv);

--- a/tests/runTests.du
+++ b/tests/runTests.du
@@ -12,6 +12,12 @@ import "tests/loops/import.du";
 import "tests/env/import.du";
 import "tests/system/import.du";
 import "tests/json/import.du";
+
+if (len(argv) > 1 and argv[1] == "--disable-http") {
+  print("All tests passed successfully!");
+  System.exit (0);
+}
+
 import "tests/http/import.du";
 
 // If we got here no runtime errors were thrown, therefore all tests passed.

--- a/tests/variables/magic.du
+++ b/tests/variables/magic.du
@@ -8,4 +8,4 @@
  * argv is a list of all parameters passed to the interpreter.
  * The first element is always the script name
  */
-assert(argv == ["tests/runTests.du"]);
+assert(argv[0] == "tests/runTests.du");


### PR DESCRIPTION
This allows for an optional building for HTTP class.

To disable it run:

make DISABLE_HTTP=1

and when running the tests use:

./dictu tests/runTests.du --disable-http

This is tested with GNU-make.