### PR TITLE
Cache variables to avoid filling constants

### DIFF
--- a/c/compiler.h
+++ b/c/compiler.h
@@ -78,6 +78,7 @@ typedef struct {
 
 typedef struct Compiler {
     Parser *parser;
+    Table stringConstants;
 
     struct Compiler *enclosing;
     ClassCompiler *class;


### PR DESCRIPTION
# Summary
> The compiler adds a global variable’s name to the constant table as a string every time an identifier is encountered. It creates a new constant each time, even if that variable name is already in a previous slot in the constant table. That’s wasteful in cases where the same variable is referenced multiple times by the same function. That in turn increases the odds of filling up the constant table and running out of slots, since we only allow 256 constants in a single chunk.