### PR TITLE
Garbage collection

### DIFF
--- a/c/datatypes/dicts.c
+++ b/c/datatypes/dicts.c
@@ -41,8 +41,8 @@ static bool removeDictItem(VM *vm, int argCount) {
         return false;
     }
 
-    char *key = AS_CSTRING(pop(vm));
-    ObjDict *dict = AS_DICT(pop(vm));
+    char *key = AS_CSTRING(peek(vm, 0));
+    ObjDict *dict = AS_DICT(peek(vm, 1));
 
     int index = hash(key) % dict->capacity;
 
@@ -58,8 +58,10 @@ static bool removeDictItem(VM *vm, int argCount) {
         dict->count--;
 
         if (dict->capacity != 8 && dict->count * 100 / dict->capacity <= 35) {
-            resizeDict(dict, false);
+            resizeDict(vm, dict, false);
         }
+        pop(vm);
+        pop(vm);
 
         push(vm, NIL_VAL);
         return true;
@@ -103,8 +105,10 @@ static bool copyDictShallow(VM *vm, int argCount) {
         return false;
     }
 
-    ObjDict *oldDict = AS_DICT(pop(vm));
-    push(vm, OBJ_VAL(copyDict(vm, oldDict, true)));
+    ObjDict *oldDict = AS_DICT(peek(vm, 0));
+    ObjDict *newDict = copyDict(vm, oldDict, true);
+    pop(vm);
+    push(vm, OBJ_VAL(newDict));
 
     return true;
 }
@@ -115,8 +119,10 @@ static bool copyDictDeep(VM *vm, int argCount) {
         return false;
     }
 
-    ObjDict *oldDict = AS_DICT(pop(vm));
-    push(vm, OBJ_VAL(copyDict(vm, oldDict, false)));
+    ObjDict *oldDict = AS_DICT(peek(vm, 0));
+    ObjDict *newDict = copyDict(vm, oldDict, false);
+    pop(vm);
+    push(vm, OBJ_VAL(newDict));
 
     return true;
 }

--- a/c/datatypes/instance.c
+++ b/c/datatypes/instance.c
@@ -71,10 +71,9 @@ static bool setAttribute(VM *vm, int argCount) {
         return false;
     }
 
-    ObjInstance *instance = AS_INSTANCE(pop(vm)); // Pop the instance
-
+    ObjInstance *instance = AS_INSTANCE(peek(vm, 0));
     tableSet(vm, &instance->fields, AS_STRING(key), value);
-
+    pop(vm);
     push(vm, NIL_VAL);
 
     return true;
@@ -86,8 +85,9 @@ static bool copyShallow(VM *vm, int argCount) {
         return false;
     }
 
-    ObjInstance *oldInstance = AS_INSTANCE(pop(vm));
+    ObjInstance *oldInstance = AS_INSTANCE(peek(vm, 0));
     ObjInstance *instance = copyInstance(vm, oldInstance, true);
+    pop(vm);
     push(vm, OBJ_VAL(instance));
 
     return true;
@@ -99,8 +99,9 @@ static bool copyDeep(VM *vm, int argCount) {
         return false;
     }
 
-    ObjInstance *oldInstance = AS_INSTANCE(pop(vm));
+    ObjInstance *oldInstance = AS_INSTANCE(peek(vm, 0));
     ObjInstance *instance = copyInstance(vm, oldInstance, false);
+    pop(vm);
     push(vm, OBJ_VAL(instance));
 
     return true;

--- a/c/datatypes/lists.c
+++ b/c/datatypes/lists.c
@@ -205,7 +205,6 @@ static bool joinListItem(VM *vm, int argCount) {
     if (!IS_STRING(list->values.values[list->values.count - 1])) {
         free(output);
     }
-    free(fullString);
 
     pop(vm);
     if (argCount == 2) {
@@ -213,6 +212,8 @@ static bool joinListItem(VM *vm, int argCount) {
     }
 
     push(vm, OBJ_VAL(copyString(vm, fullString, index)));
+
+    free(fullString);
 
     return true;
 }

--- a/c/datatypes/sets.c
+++ b/c/datatypes/sets.c
@@ -48,7 +48,7 @@ static bool removeSetItem(VM *vm, int argCount) {
         set->count--;
 
         if (set->capacity != 8 && set->count * 100 / set->capacity <= 35) {
-            resizeSet(set, false);
+            resizeSet(vm, set, false);
         }
 
         pop(vm);

--- a/c/datatypes/sets.c
+++ b/c/datatypes/sets.c
@@ -11,9 +11,11 @@ static bool addSetItem(VM *vm, int argCount) {
         return false;
     }
 
-    Value value = pop(vm);
-    ObjSet *set = AS_SET(pop(vm));
+    Value value = peek(vm, 0);
+    ObjSet *set = AS_SET(peek(vm, 1));
     insertSet(vm, set, value);
+    pop(vm);
+    pop(vm);
     push(vm, NIL_VAL);
 
     return true;
@@ -30,8 +32,8 @@ static bool removeSetItem(VM *vm, int argCount) {
         return false;
     }
 
-    ObjString *string = AS_STRING(pop(vm));
-    ObjSet *set = AS_SET(pop(vm));
+    ObjString *string = AS_STRING(peek(vm, 0));
+    ObjSet *set = AS_SET(peek(vm, 1));
     int index = string->hash % set->capacity;
 
     while (set->items[index] && !(strcmp(set->items[index]->item->chars, string->chars) == 0 && !set->items[index]->deleted)) {
@@ -48,6 +50,9 @@ static bool removeSetItem(VM *vm, int argCount) {
         if (set->capacity != 8 && set->count * 100 / set->capacity <= 35) {
             resizeSet(set, false);
         }
+
+        pop(vm);
+        pop(vm);
 
         push(vm, NIL_VAL);
         return true;

--- a/c/value.c
+++ b/c/value.c
@@ -54,7 +54,7 @@ static uint32_t hash(char *str) {
 
 void insertDict(VM *vm, ObjDict *dict, char *key, Value value) {
     if (dict->count * 100 / dict->capacity >= 60) {
-        resizeDict(dict, true);
+        resizeDict(vm, dict, true);
     }
 
     uint32_t hashValue = hash(key);
@@ -104,7 +104,7 @@ void insertDict(VM *vm, ObjDict *dict, char *key, Value value) {
     dict->count++;
 }
 
-void resizeDict(ObjDict *dict, bool grow) {
+void resizeDict(VM *vm, ObjDict *dict, bool grow) {
     int newSize;
 
     if (grow)
@@ -112,7 +112,7 @@ void resizeDict(ObjDict *dict, bool grow) {
     else
         newSize = dict->capacity >> 1; // Shrink by a factor of 2
 
-    dictItem **items = calloc(newSize, sizeof(*dict->items));
+    dictItem **items = (dictItem **)ALLOCATE(vm, setItem, newSize);
 
     for (int j = 0; j < dict->capacity; ++j) {
         if (!dict->items[j])
@@ -177,7 +177,7 @@ void insertSet(VM *vm, ObjSet *set, Value value) {
     setItem *item = ALLOCATE(vm, setItem, sizeof(setItem));
 
     if (set->count * 100 / set->capacity >= 60) {
-        resizeSet(set, true);
+        resizeSet(vm, set, true);
     }
 
     item->item = string;
@@ -230,7 +230,7 @@ bool searchSetMarkActive(ObjSet *set, ObjString *string) {
     return false;
 }
 
-void resizeSet(ObjSet *set, bool grow) {
+void resizeSet(VM *vm, ObjSet *set, bool grow) {
     int newSize;
 
     if (grow)
@@ -238,7 +238,7 @@ void resizeSet(ObjSet *set, bool grow) {
     else
         newSize = set->capacity >> 1;
 
-    setItem **items = calloc(newSize, sizeof(*set->items));
+    setItem **items = (setItem **)ALLOCATE(vm, setItem, newSize);
 
     for (int j = 0; j < set->capacity; ++j) {
         if (!set->items[j])

--- a/c/value.h
+++ b/c/value.h
@@ -126,7 +126,7 @@ void initSetValues(ObjSet *set, uint32_t capacity);
 
 void insertDict(VM *vm, ObjDict *dict, char *key, Value value);
 
-void resizeDict(ObjDict *dict, bool grow);
+void resizeDict(VM *vm, ObjDict *dict, bool grow);
 
 Value searchDict(ObjDict *dict, char *key);
 
@@ -136,7 +136,7 @@ bool searchSet(ObjSet *set, ObjString *string);
 
 bool searchSetMarkActive(ObjSet *set, ObjString *string);
 
-void resizeSet(ObjSet *set, bool grow);
+void resizeSet(VM *vm, ObjSet *set, bool grow);
 
 char *valueToString(Value value);
 

--- a/tests/benchmarks/list-methods/join.du
+++ b/tests/benchmarks/list-methods/join.du
@@ -1,7 +1,7 @@
-var start = clock();
+var start = System.clock();
 
 for (var i = 0; i < 10000; ++i) {
     ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'].join("");
 }
 
-print(clock() - start);
+print(System.clock() - start);


### PR DESCRIPTION
# Summary
This PR fixes some pretty rare edge cases where values were being cleaned up by the GC prematurely. For example, if you `.insert()` on a literal list value (why would you in reality?), and you are at the point that the list needed to resize, this would cause the list to be cleaned up, as there is no reference to the list in variables, and it's not on the stack. 