### PR TITLE
Remove doubled "dict" logic as we can just use the Table type

### DIFF
--- a/c/datatypes/copy.c
+++ b/c/datatypes/copy.c
@@ -37,7 +37,6 @@ ObjDict *copyDict(VM* vm, ObjDict *oldDict, bool shallow) {
         // Push to stack to avoid GC
         push(vm, val);
         tableSet(vm, &newDict->items, oldDict->items.entries[i].key, val);
-        // insertDict(vm, newDict, oldDict->items[i]->key, val);
         pop(vm);
     }
 

--- a/c/datatypes/copy.c
+++ b/c/datatypes/copy.c
@@ -17,12 +17,12 @@ ObjDict *copyDict(VM* vm, ObjDict *oldDict, bool shallow) {
     // Push to stack to avoid GC
     push(vm, OBJ_VAL(newDict));
 
-    for (int i = 0; i < oldDict->capacity; ++i) {
-        if (oldDict->items[i] == NULL) {
+    for (int i = 0; i <= oldDict->items.capacityMask; ++i) {
+        if (oldDict->items.entries[i].key == NULL) {
             continue;
         }
 
-        Value val = oldDict->items[i]->item;
+        Value val = oldDict->items.entries[i].value;
 
         if (!shallow) {
             if (IS_DICT(val)) {
@@ -36,7 +36,8 @@ ObjDict *copyDict(VM* vm, ObjDict *oldDict, bool shallow) {
 
         // Push to stack to avoid GC
         push(vm, val);
-        insertDict(vm, newDict, oldDict->items[i]->key, val);
+        tableSet(vm, &newDict->items, oldDict->items.entries[i].key, val);
+        // insertDict(vm, newDict, oldDict->items[i]->key, val);
         pop(vm);
     }
 

--- a/c/memory.c
+++ b/c/memory.c
@@ -33,11 +33,13 @@ void *reallocate(VM *vm, void *previous, size_t oldSize, size_t newSize) {
     return realloc(previous, newSize);
 }
 
+/*
 void freeDictValue(dictItem *item) {
     free(item->key);
     free(item);
 }
-
+ */
+/*
 void freeDict(ObjDict *dict) {
     for (int i = 0; i < dict->capacity; i++) {
         dictItem *item = dict->items[i];
@@ -48,6 +50,7 @@ void freeDict(ObjDict *dict) {
     free(dict->items);
     free(dict);
 }
+*/
 
 void freeSetValue (setItem *item) {
     free(item);
@@ -173,12 +176,15 @@ static void blackenObject(VM *vm, Obj *object) {
 
         case OBJ_DICT: {
             ObjDict *dict = (ObjDict *) object;
+            grayTable(vm, &dict->items);
+            /*
             for (int i = 0; i < dict->capacity; ++i) {
                 if (!dict->items[i])
                     continue;
 
                 grayValue(vm, dict->items[i]->item);
             }
+             */
             break;
         }
 
@@ -275,7 +281,8 @@ void freeObject(VM *vm, Obj *object) {
 
         case OBJ_DICT: {
             ObjDict *dict = (ObjDict *) object;
-            freeDict(dict);
+            freeTable(vm, &dict->items);
+            FREE(vm, ObjDict, dict);
             break;
         }
 

--- a/c/memory.c
+++ b/c/memory.c
@@ -33,25 +33,6 @@ void *reallocate(VM *vm, void *previous, size_t oldSize, size_t newSize) {
     return realloc(previous, newSize);
 }
 
-/*
-void freeDictValue(dictItem *item) {
-    free(item->key);
-    free(item);
-}
- */
-/*
-void freeDict(ObjDict *dict) {
-    for (int i = 0; i < dict->capacity; i++) {
-        dictItem *item = dict->items[i];
-        if (item != NULL) {
-            freeDictValue(item);
-        }
-    }
-    free(dict->items);
-    free(dict);
-}
-*/
-
 void freeSetValue (setItem *item) {
     free(item);
 }

--- a/c/memory.c
+++ b/c/memory.c
@@ -158,14 +158,6 @@ static void blackenObject(VM *vm, Obj *object) {
         case OBJ_DICT: {
             ObjDict *dict = (ObjDict *) object;
             grayTable(vm, &dict->items);
-            /*
-            for (int i = 0; i < dict->capacity; ++i) {
-                if (!dict->items[i])
-                    continue;
-
-                grayValue(vm, dict->items[i]->item);
-            }
-             */
             break;
         }
 

--- a/c/memory.h
+++ b/c/memory.h
@@ -32,9 +32,9 @@ void freeObjects(VM *vm);
 
 void freeObject(VM *vm, Obj *object);
 
-void freeDictValue(dictItem *item);
+// void freeDictValue(dictItem *item);
 
-void freeDict(ObjDict *item);
+// void freeDict(ObjDict *item);
 
 void freeSetValue(setItem *item);
 

--- a/c/memory.h
+++ b/c/memory.h
@@ -32,10 +32,6 @@ void freeObjects(VM *vm);
 
 void freeObject(VM *vm, Obj *object);
 
-// void freeDictValue(dictItem *item);
-
-// void freeDict(ObjDict *item);
-
 void freeSetValue(setItem *item);
 
 #endif

--- a/c/natives.c
+++ b/c/natives.c
@@ -112,7 +112,7 @@ static Value lenNative(VM *vm, int argCount, Value *args) {
     } else if (IS_LIST(args[0])) {
         return NUMBER_VAL(AS_LIST(args[0])->values.count);
     } else if (IS_DICT(args[0])) {
-        return NUMBER_VAL(AS_DICT(args[0])->count);
+        return NUMBER_VAL(AS_DICT(args[0])->items.count);
     } else if (IS_SET(args[0])) {
         return NUMBER_VAL(AS_SET(args[0])->count);
     }

--- a/c/object.h
+++ b/c/object.h
@@ -102,11 +102,6 @@ struct dictItem {
 struct sObjDict {
     Obj obj;
     Table items;
-    /*
-    int capacity;
-    int count;
-    dictItem **items;
-     */
 };
 
 struct setItem {

--- a/c/object.h
+++ b/c/object.h
@@ -101,9 +101,12 @@ struct dictItem {
 
 struct sObjDict {
     Obj obj;
+    Table items;
+    /*
     int capacity;
     int count;
     dictItem **items;
+     */
 };
 
 struct setItem {

--- a/c/table.c
+++ b/c/table.c
@@ -101,6 +101,7 @@ bool tableDelete(Table *table, ObjString *key) {
     if (entry->key == NULL) return false;
 
     // Place a tombstone in the entry.
+    table->count--;
     entry->key = NULL;
     entry->value = BOOL_VAL(true);
 

--- a/c/value.c
+++ b/c/value.c
@@ -30,133 +30,10 @@ void freeValueArray(VM *vm, ValueArray *array) {
     initValueArray(array);
 }
 
-void initDictValues(ObjDict *dict, uint32_t capacity) {
-    dict->capacity = capacity;
-    dict->count = 0;
-    dict->items = calloc(capacity, sizeof(*dict->items));
-}
-
 void initSetValues(ObjSet *set, uint32_t capacity) {
     set->capacity = capacity;
     set->count = 0;
     set->items = calloc(capacity, sizeof(*set->items));
-}
-
-static uint32_t hash(char *str) {
-    uint32_t hash = 5381;
-    int c;
-
-    while ((c = *str++))
-        hash = ((hash << 5) + hash) + c;
-
-    return hash;
-}
-
-void insertDict(VM *vm, ObjDict *dict, char *key, Value value) {
-    if (dict->count * 100 / dict->capacity >= 60) {
-        resizeDict(vm, dict, true);
-    }
-
-    uint32_t hashValue = hash(key);
-    int index = hashValue % dict->capacity;
-
-    char *key_m = ALLOCATE(vm, char, strlen(key) + 1);
-
-    if (!key_m) {
-        printf("ERROR!");
-        return;
-    }
-
-    strcpy(key_m, key);
-
-    dictItem *item = ALLOCATE(vm, dictItem, sizeof(dictItem));
-
-    if (!item) {
-        printf("ERROR!");
-        return;
-    }
-
-    item->key = key_m;
-    item->item = value;
-    item->deleted = false;
-    item->hash = hashValue;
-
-    while (dict->items[index] && strcmp(dict->items[index]->key, key) != 0) {
-        index++;
-        if (index == dict->capacity) {
-            index = 0;
-        }
-    }
-
-    // Replace the value
-    if (dict->items[index]) {
-        // If the key is not "deleted", we are updating the value, not inserting
-        // a new entry, therefore count should not change
-        if (!dict->items[index]->deleted) {
-            dict->count--;
-        }
-
-        free(dict->items[index]->key);
-        free(dict->items[index]);
-    }
-
-    dict->items[index] = item;
-    dict->count++;
-}
-
-void resizeDict(VM *vm, ObjDict *dict, bool grow) {
-    int newSize;
-
-    if (grow)
-        newSize = dict->capacity << 1; // Grow by a factor of 2
-    else
-        newSize = dict->capacity >> 1; // Shrink by a factor of 2
-
-    dictItem **items = (dictItem **)ALLOCATE(vm, setItem, newSize);
-
-    for (int j = 0; j < dict->capacity; ++j) {
-        if (!dict->items[j])
-            continue;
-
-        if (dict->items[j]->deleted) {
-            freeDictValue(dict->items[j]);
-            continue;
-        }
-
-        int index = dict->items[j]->hash % newSize;
-
-        while (items[index]) {
-            index = (index + 1) % newSize; // Handles wrap around indexes
-        }
-
-        items[index] = dict->items[j];
-    }
-
-    free(dict->items);
-
-    dict->capacity = newSize;
-    dict->items = items;
-}
-
-Value searchDict(ObjDict *dict, char *key) {
-    int index = hash(key) % dict->capacity;
-
-    if (!dict->items[index]) {
-        return NIL_VAL;
-    }
-
-    while (dict->items[index] && !dict->items[index]->deleted && strcmp(dict->items[index]->key, key) != 0) {
-        index++;
-        if (index == dict->capacity) {
-            index = 0;
-        }
-    }
-
-    if (dict->items[index] && !dict->items[index]->deleted) {
-        return dict->items[index]->item;
-    }
-
-    return NIL_VAL;
 }
 
 void insertSet(VM *vm, ObjSet *set, Value value) {
@@ -316,26 +193,26 @@ static bool dictComparison(Value a, Value b) {
     ObjDict *dictB = AS_DICT(b);
 
     // Different lengths, not the same
-    if (dict->count != dictB->count)
+    if (dict->items.count != dictB->items.count)
         return false;
 
     // Lengths are the same, and dict 1 has 0 length
     // therefore both are empty
-    if (dict->count == 0)
+    if (dict->items.count == 0)
         return true;
 
-    for (int i = 0; i < dict->capacity; ++i) {
-        dictItem *item = dict->items[i];
-        dictItem *itemB = dictB->items[i];
+    for (int i = 0; i <= dict->items.capacityMask; ++i) {
+        Entry *item = &dict->items.entries[i];
+        Entry *itemB = &dictB->items.entries[i];
 
-        if (!item || !itemB) {
+        if (item->key == NULL || itemB->key == NULL) {
             continue;
         }
 
-        if (strcmp(item->key, itemB->key) != 0)
+        if (!valuesEqual(OBJ_VAL(item->key), OBJ_VAL(itemB->key)))
             return false;
 
-        if (!valuesEqual(item->item, itemB->item))
+        if (!valuesEqual(item->value, itemB->value))
             return false;
     }
 

--- a/c/value.h
+++ b/c/value.h
@@ -7,7 +7,6 @@ typedef struct sObj Obj;
 typedef struct sObjString ObjString;
 typedef struct sObjList ObjList;
 typedef struct sObjDict ObjDict;
-typedef struct dictItem dictItem;
 typedef struct sObjSet  ObjSet;
 typedef struct setItem  setItem;
 typedef struct sObjFile ObjFile;
@@ -120,15 +119,7 @@ void writeValueArray(VM *vm, ValueArray *array, Value value);
 
 void freeValueArray(VM *vm, ValueArray *array);
 
-void initDictValues(ObjDict *dict, uint32_t capacity);
-
 void initSetValues(ObjSet *set, uint32_t capacity);
-
-void insertDict(VM *vm, ObjDict *dict, char *key, Value value);
-
-void resizeDict(VM *vm, ObjDict *dict, bool grow);
-
-Value searchDict(ObjDict *dict, char *key);
 
 void insertSet(VM *vm, ObjSet *set, Value value);
 

--- a/c/vm.c
+++ b/c/vm.c
@@ -941,7 +941,6 @@ static InterpretResult run(VM *vm) {
             ObjDict *dict = AS_DICT(dictValue);
             ObjString *keyString = AS_STRING(key);
 
-            // insertDict(vm, dict, keyString, value);
             tableSet(vm, &dict->items, keyString, value);
 
             pop(vm);
@@ -1086,7 +1085,6 @@ static InterpretResult run(VM *vm) {
                     ObjDict *dict = AS_DICT(subscriptValue);
                     ObjString *keyString = AS_STRING(indexValue);
 
-                    // insertDict(vm, dict, keyString, value);
                     tableSet(vm, &dict->items, keyString, assignValue);
 
                     // Pop after the values have been inserted to stop GC cleanup


### PR DESCRIPTION
# Remove dict logic
## Summary
Currently the implementation if dicts in Dictu is duplicated. There is a Table type which is used internally, and there is a dict object which does the same thing - perform as a hash table. This PR removes the duplicated logic to instead use the present Table type which is used internally throughout the code base already - much like how lists work with ValueArrays.