### PR TITLE
Correctly free new tables

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -143,10 +143,10 @@ static void patchJump(Compiler *compiler, int offset) {
 static void initCompiler(Parser *parser, Compiler *compiler, Compiler *parent, FunctionType type) {
     compiler->parser = parser;
     compiler->enclosing = parent;
+    initTable(&compiler->stringConstants);
     compiler->function = NULL;
     compiler->class = NULL;
     compiler->loop = NULL;
-    initTable(&compiler->stringConstants);
 
     if (parent != NULL) {
         compiler->class = parent->class;
@@ -1659,7 +1659,6 @@ void grayCompilerRoots(VM *vm) {
 
     while (compiler != NULL) {
         grayObject(vm, (Obj *) compiler->function);
-        // if (compiler->stringConstants != NULL)
         grayTable(vm, &compiler->stringConstants);
         compiler = compiler->enclosing;
     }

--- a/c/compiler.c
+++ b/c/compiler.c
@@ -142,11 +142,11 @@ static void patchJump(Compiler *compiler, int offset) {
 
 static void initCompiler(Parser *parser, Compiler *compiler, Compiler *parent, FunctionType type) {
     compiler->parser = parser;
-    initTable(&compiler->stringConstants);
     compiler->enclosing = parent;
     compiler->function = NULL;
     compiler->class = NULL;
     compiler->loop = NULL;
+    initTable(&compiler->stringConstants);
 
     if (parent != NULL) {
         compiler->class = parent->class;
@@ -217,6 +217,7 @@ static ObjFunction *endCompiler(Compiler *compiler) {
         }
     }
 
+    freeTable(compiler->parser->vm, &compiler->stringConstants);
     compiler->parser->vm->compiler = compiler->enclosing;
     return function;
 }
@@ -1646,7 +1647,6 @@ ObjFunction *compile(VM *vm, const char *source) {
         } while (!match(&compiler, TOKEN_EOF));
     }
 
-    freeTable(vm, &compiler.stringConstants);
     ObjFunction *function = endCompiler(&compiler);
 
     // If there was a compile error, the code is not valid, so don't
@@ -1659,6 +1659,7 @@ void grayCompilerRoots(VM *vm) {
 
     while (compiler != NULL) {
         grayObject(vm, (Obj *) compiler->function);
+        // if (compiler->stringConstants != NULL)
         grayTable(vm, &compiler->stringConstants);
         compiler = compiler->enclosing;
     }

--- a/c/vm.c
+++ b/c/vm.c
@@ -142,6 +142,12 @@ void freeVM(VM *vm) {
     freeTable(vm, &vm->globals);
     freeTable(vm, &vm->strings);
     freeTable(vm, &vm->imports);
+    freeTable(vm, &vm->stringMethods);
+    freeTable(vm, &vm->listMethods);
+    freeTable(vm, &vm->dictMethods);
+    freeTable(vm, &vm->setMethods);
+    freeTable(vm, &vm->fileMethods);
+    freeTable(vm, &vm->instanceMethods);
     FREE_ARRAY(vm, CallFrame, vm->frames, vm->frameCapacity);
     vm->initString = NULL;
     vm->replVar = NULL;


### PR DESCRIPTION
# Hotfix
## Summary
Since the 0.4.0 release there was an introduction of a new `stringConstants` table within the compiler. This is getting free'd in the `compile()` function however the table is being created and used in the `initCompiler` stage. `initCompiler` is used without necessarily calling `compile` (functions) meaning there is some memory not being free'd - This PR fixes that. It also fixes new native method tables not being free'd when the VM is cleaned up. 