### PR TITLE
Add native class properties

### DIFF
--- a/c/memory.c
+++ b/c/memory.c
@@ -112,6 +112,7 @@ static void blackenObject(VM *vm, Obj *object) {
             ObjClassNative *klass = (ObjClassNative *) object;
             grayObject(vm, (Obj *) klass->name);
             grayTable(vm, &klass->methods);
+            grayTable(vm, &klass->properties);
             break;
         }
 
@@ -201,6 +202,7 @@ void freeObject(VM *vm, Obj *object) {
         case OBJ_NATIVE_CLASS: {
             ObjClassNative *klass = (ObjClassNative *) object;
             freeTable(vm, &klass->methods);
+            freeTable(vm, &klass->properties);
             FREE(vm, ObjClass, object);
             break;
         }

--- a/c/object.c
+++ b/c/object.c
@@ -47,6 +47,7 @@ ObjClassNative *newClassNative(VM *vm, ObjString *name) {
     ObjClassNative *klass = ALLOCATE_OBJ(vm, ObjClassNative, OBJ_NATIVE_CLASS);
     klass->name = name;
     initTable(&klass->methods);
+    initTable(&klass->properties);
     return klass;
 }
 

--- a/c/object.h
+++ b/c/object.h
@@ -159,6 +159,7 @@ typedef struct sObjClassNative {
     Obj obj;
     ObjString *name;
     Table methods;
+    Table properties;
 } ObjClassNative;
 
 typedef struct sObjTrait {

--- a/c/optionals/math.c
+++ b/c/optionals/math.c
@@ -185,6 +185,11 @@ void createMathsClass(VM *vm) {
     defineNative(vm, &klass->methods, "min", minNative);
     defineNative(vm, &klass->methods, "sum", sumNative);
 
+    /**
+     * Define Math properties
+     */
+    defineNativeProperty(vm, &klass->properties, "PI", NUMBER_VAL(3.14159265358979));
+
     tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
     pop(vm);
     pop(vm);

--- a/c/optionals/math.c
+++ b/c/optionals/math.c
@@ -189,6 +189,7 @@ void createMathsClass(VM *vm) {
      * Define Math properties
      */
     defineNativeProperty(vm, &klass->properties, "PI", NUMBER_VAL(3.14159265358979));
+    defineNativeProperty(vm, &klass->properties, "e", NUMBER_VAL(2.71828182845905));
 
     tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
     pop(vm);

--- a/c/util.c
+++ b/c/util.c
@@ -43,6 +43,15 @@ void defineNative(VM *vm, Table *table, const char *name, NativeFn function) {
     pop(vm);
 }
 
+void defineNativeProperty(VM *vm, Table *table, const char *name, Value value) {
+    push(vm, value);
+    ObjString *propertyName = copyString(vm, name, strlen(name));
+    push(vm, OBJ_VAL(propertyName));
+    tableSet(vm, table, propertyName, value);
+    pop(vm);
+    pop(vm);
+}
+
 bool isValidKey(Value value) {
     if (IS_NIL(value) || IS_BOOL(value) || IS_NUMBER(value) ||
     IS_STRING(value)) {

--- a/c/util.h
+++ b/c/util.h
@@ -7,6 +7,8 @@ char *readFile(const char *path);
 
 void defineNative(VM *vm, Table *table, const char *name, NativeFn function);
 
+void defineNativeProperty(VM *vm, Table *table, const char *name, Value value);
+
 bool isValidKey(Value value);
 
 #endif //dictu_util_h

--- a/docs/docs/math.md
+++ b/docs/docs/math.md
@@ -20,6 +20,13 @@ nav_order: 11
 Functions relating to mathematics are behind the Math namespace. For the purpose of the documentation, and iterable
 is either a list, or passing multiple arguments to the function directly.
 
+### Constants
+
+| Constant  | Description                                            |
+|-----------|--------------------------------------------------------|
+| Math.PI   | The mathematical constant: 3.14159265358979            |
+| Math.e    | The mathematical constant: 2.71828182845905            |
+
 ### Math.min(iterable)
 
 Return the smallest number within the iterable

--- a/tests/maths/maths.du
+++ b/tests/maths/maths.du
@@ -1,10 +1,13 @@
 /**
-* maths.du
-*
-* Testing the Math functions:
-*    - min(), max(), average(), sum(), floor(), round(), ceil(), abs()
-*
-*/
+ * maths.du
+ *
+ * Testing the Math functions:
+ *    - min(), max(), average(), sum(), floor(), round(), ceil(), abs()
+ *
+ * Testing the Math constants:
+ *    - PI, e
+ *
+ */
 
 assert(Math.min(1, 2, 3) == 1);
 assert(Math.min([1, 2, 3]) == 1);
@@ -19,3 +22,6 @@ assert(Math.round(17.5) == 18);
 assert(Math.ceil(17.0001) == 18);
 assert(Math.abs(18) == 18);
 assert(Math.abs(-18) == 18);
+
+assert(Math.PI == 3.14159265358979);
+assert(Math.e == 2.71828182845905);


### PR DESCRIPTION
# Add native class properties
Resolves #170 
## Summary
This PR adds the ability to add methods to native classes, the purpose of this change is to add the ability to define "constants" on respective classes. For example, this PR adds two new constants to the Math class, Pi, and e.