### PR TITLE
Move argv magic variable into the System native class

### DIFF
--- a/c/optionals/http.h
+++ b/c/optionals/http.h
@@ -17,6 +17,6 @@ typedef struct response {
     long statusCode;
 } Response;
 
-void createHTTPClass();
+void createHTTPClass(VM *vm);
 
 #endif //dictu_http_h

--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -95,7 +95,7 @@ void initArgv(VM *vm, Table *table, int argc, const char *argv[]) {
         pop(vm);
     }
 
-    tableSet(vm, table, copyString(vm, "argv", 4), OBJ_VAL(list));
+    defineNativeProperty(vm, table, "argv", OBJ_VAL(list));
     pop(vm);
 }
 

--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -84,7 +84,22 @@ static Value exitNative(VM *vm, int argCount, Value *args) {
 
 }
 
-void createSystemClass(VM *vm) {
+void initArgv(VM *vm, Table *table, int argc, const char *argv[]) {
+    ObjList *list = initList(vm);
+    push(vm, OBJ_VAL(list));
+
+    for (int i = 1; i < argc; i++) {
+        Value arg = OBJ_VAL(copyString(vm, argv[i], strlen(argv[i])));
+        push(vm, arg);
+        writeValueArray(vm, &list->values, arg);
+        pop(vm);
+    }
+
+    tableSet(vm, table, copyString(vm, "argv", 4), OBJ_VAL(list));
+    pop(vm);
+}
+
+void createSystemClass(VM *vm, int argc, const char *argv[]) {
     ObjString *name = copyString(vm, "System", 6);
     push(vm, OBJ_VAL(name));
     ObjClassNative *klass = newClassNative(vm, name);
@@ -100,6 +115,14 @@ void createSystemClass(VM *vm) {
     defineNative(vm, &klass->methods, "collect", collectNative);
     defineNative(vm, &klass->methods, "sleep", sleepNative);
     defineNative(vm, &klass->methods, "exit", exitNative);
+
+    /**
+     * Define System properties
+     */
+    if (!vm->repl) {
+        // Set argv variable
+        initArgv(vm, &klass->properties, argc, argv);
+    }
 
     tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
     pop(vm);

--- a/c/optionals/system.h
+++ b/c/optionals/system.h
@@ -15,6 +15,6 @@
 #include "../vm.h"
 #include "../memory.h"
 
-void createSystemClass();
+void createSystemClass(VM *vm, int argc, const char *argv[]);
 
 #endif //dictu_system_h

--- a/c/vm.c
+++ b/c/vm.c
@@ -59,21 +59,6 @@ void runtimeError(VM *vm, const char *format, ...) {
     resetStack(vm);
 }
 
-void initArgv(VM *vm, int argc, const char *argv[]) {
-    ObjList *list = initList(vm);
-    push(vm, OBJ_VAL(list));
-
-    for (int i = 1; i < argc; i++) {
-        Value arg = OBJ_VAL(copyString(vm, argv[i], strlen(argv[i])));
-        push(vm, arg);
-        writeValueArray(vm, &list->values, arg);
-        pop(vm);
-    }
-
-    tableSet(vm, &vm->globals, copyString(vm, "argv", 4), OBJ_VAL(list));
-    pop(vm);
-}
-
 VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
     VM *vm = malloc(sizeof(*vm));
 
@@ -124,17 +109,11 @@ VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
     // Native classes
     createMathsClass(vm);
     createEnvClass(vm);
-    createSystemClass(vm);
+    createSystemClass(vm, argc, argv);
     createJSONClass(vm);
 #ifndef DISABLE_HTTP
     createHTTPClass(vm);
 #endif
-
-
-    if (!vm->repl) {
-        initArgv(vm, argc, argv);
-    }
-
     return vm;
 }
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -69,26 +69,4 @@ comment
 */
 ```
 
-## Argv
-
-Passing arguments to the script via the CLI is very important, especially in a headless environment. Dictu allows you to access these arguments very easily with the magic `argv` variable. `argv` is a list of all arguments supplied to the script. This will be more apparent with the following examples. Note - the first element of the argv list is always the script name.
-
-### CLI
-
-`./dictu myFile.du`
-
-```js
-# myFile.du
-
-print(argv); // ["myDile.du"]
-```
-
-`./dictu myFile.du arg1 arg2 arg3`
-
-```js
-# myFile.du
-
-print(argv); // ["myDile.du", "arg1", "arg2", "arg3"]
-```
-
 {: .no_toc }

--- a/docs/docs/system.md
+++ b/docs/docs/system.md
@@ -15,6 +15,12 @@ nav_order: 13
 
 ---
 
+### Constants
+
+| Constant      | Description                                                                                       |
+|---------------|---------------------------------------------------------------------------------------------------|
+| System.argv   | The list of command line arguments. The first element of the argv list is always the script name. |
+
 ### System.getCWD()
 
 Get current working directory of the Dictu process returned as a string

--- a/tests/system/constants.du
+++ b/tests/system/constants.du
@@ -1,11 +1,12 @@
 /**
- * magic.du
+ * constants.du
  *
- * Testing "magic" variables are set correctly
+ * Testing the System constants
+ *
  */
 
 /**
  * argv is a list of all parameters passed to the interpreter.
  * The first element is always the script name
  */
-assert(argv[0] == "tests/runTests.du");
+assert(System.argv[0] == "tests/runTests.du");

--- a/tests/variables/import.du
+++ b/tests/variables/import.du
@@ -6,4 +6,3 @@
 
 import "tests/variables/scope.du";
 import "tests/variables/assignment.du";
-import "tests/variables/magic.du";


### PR DESCRIPTION
# Summary
This moves the magic `argv` variable into the System native class. This means it's behind a namespace and `argv` is now free to be used as a variable name.