### PR TITLE
Cleanup

### DIFF
--- a/c/debug.c
+++ b/c/debug.c
@@ -134,7 +134,7 @@ int disassembleInstruction(Chunk *chunk, int offset) {
         case OP_LOOP:
             return jumpInstruction("OP_LOOP", -1, chunk, offset);
         case OP_IMPORT:
-            return simpleInstruction("OP_IMPORT", offset);
+            return constantInstruction("OP_IMPORT", chunk, offset);
         case OP_IMPORT_END:
             return simpleInstruction("OP_IMPORT_END", offset);
         case OP_NEW_LIST:

--- a/c/natives.c
+++ b/c/natives.c
@@ -119,8 +119,8 @@ static Value inputNative(VM *vm, int argCount, Value *args) {
         printf("%s", AS_CSTRING(prompt));
     }
 
-    uint8_t current_size = 128;
-    char *line = malloc(current_size);
+    uint64_t currentSize = 128;
+    char *line = malloc(currentSize);
 
     if (line == NULL) {
         runtimeError(vm, "Memory error on input()!");
@@ -128,13 +128,13 @@ static Value inputNative(VM *vm, int argCount, Value *args) {
     }
 
     int c = EOF;
-    uint8_t i = 0;
+    uint64_t i = 0;
     while ((c = getchar()) != '\n' && c != EOF) {
         line[i++] = (char) c;
 
-        if (i == current_size) {
-            current_size = GROW_CAPACITY(current_size);
-            line = realloc(line, current_size);
+        if (i + 1 == currentSize) {
+            currentSize = GROW_CAPACITY(currentSize);
+            line = realloc(line, currentSize);
 
             if (line == NULL) {
                 printf("Unable to allocate memory\n");

--- a/c/optionals/http.c
+++ b/c/optionals/http.c
@@ -7,19 +7,14 @@ static void createResponse(VM *vm, Response *response) {
     push(vm, OBJ_VAL(response->headers));
 
     response->len = 0;
-    response->res = ALLOCATE(vm, char, 1);
-    if (response->res == NULL) {
-        printf("Unable to allocate memory\n");
-        exit(71);
-    }
-    response->res[0] = '\0';
+    response->res = NULL;
 }
 
 static size_t writeResponse(char *ptr, size_t size, size_t nmemb, void *data)
 {
     Response *response = (Response *) data;
     size_t new_len = response->len + size * nmemb;
-    response->res = GROW_ARRAY(response->vm, response->res, char, response->len, new_len);
+    response->res = GROW_ARRAY(response->vm, response->res, char, response->len, new_len + 1);
     if (response->res == NULL) {
         printf("Unable to allocate memory\n");
         exit(71);

--- a/c/value.h
+++ b/c/value.h
@@ -126,9 +126,6 @@ bool dictGet(ObjDict *dict, Value key, Value *value);
 
 bool dictDelete(VM *vm, ObjDict *dict, Value key);
 
-
-
-
 bool setGet(ObjSet *set, Value value);
 
 bool setInsert(VM *vm, ObjSet *set, Value value);
@@ -136,8 +133,6 @@ bool setInsert(VM *vm, ObjSet *set, Value value);
 bool setDelete(VM *vm, ObjSet *set, Value value);
 
 void graySet(VM *vm, ObjSet *set);
-
-
 
 char *valueToString(Value value);
 

--- a/tests/http/get.du
+++ b/tests/http/get.du
@@ -5,6 +5,14 @@
  *
  */
 
+// HTTP
+var response = HTTP.get("http://httpbin.org/get");
+
+assert(response["statusCode"] == 200);
+assert(response["content"].contains("headers"));
+assert(response["headers"].len() > 0);
+
+// HTTPS
 var response = HTTP.get("https://httpbin.org/get");
 
 assert(response["statusCode"] == 200);

--- a/tests/http/post.du
+++ b/tests/http/post.du
@@ -8,8 +8,6 @@
 // HTTP
 var response = HTTP.post("http://httpbin.org/post", {"test": 10});
 
-print(response);
-
 assert(response["statusCode"] == 200);
 assert(response["headers"].len() > 0);
 assert(response["content"].contains("origin"));

--- a/tests/http/post.du
+++ b/tests/http/post.du
@@ -5,6 +5,17 @@
  *
  */
 
+// HTTP
+var response = HTTP.post("http://httpbin.org/post", {"test": 10});
+
+print(response);
+
+assert(response["statusCode"] == 200);
+assert(response["headers"].len() > 0);
+assert(response["content"].contains("origin"));
+assert(response["content"].contains('"test": "10"'));
+
+// HTTPS
 var response = HTTP.post("https://httpbin.org/post", {"test": 10});
 
 assert(response["statusCode"] == 200);


### PR DESCRIPTION
# Cleanup
Resolves #181 
## Summary
This PR is another round of cleanups
Changes:
- Change disassembleChunk to use filename rather than "<script>"
- Emit the filename along with the `OP_IMPORT` opcode to remove the intermediate `OP_CONSTANT`
- Move `OP_IMPORT_END` into the importStatement function
- Fixed bug with `input()` where it wouldn't successfully grow in capacity. Also fixed an issue where it was using uint8_t, meaning there could be a maximum of 255 chars.
- Update runtime error raised for `input()`. Previously stated it takes 1 argument, when it can also take 0
- Add argCount check for assert, and change assert to check for falsey values rather than a hard requirement on booleans
- Refactor HTTP class.
    - Fixed a bug where the response dictionary keys were being cleaned up before they could be used
    - Moved a lot of like functionality from get and post into a shared function
    - Use memory.h macros for allocating response and use takeString, reducing 1 malloc call
    - Added ***http*** test to both get and post
- Remove `BITWISE_OP` macro as this was almost a carbon copy of `BINARY_OP`. `BINARY_OP` now just takes a type