### PR TITLE
toBool

### DIFF
--- a/c/datatypes/dicts.c
+++ b/c/datatypes/dicts.c
@@ -128,4 +128,5 @@ void declareDictMethods(VM *vm) {
     defineNative(vm, &vm->dictMethods, "exists", dictItemExists);
     defineNative(vm, &vm->dictMethods, "copy", copyDictShallow);
     defineNative(vm, &vm->dictMethods, "deepCopy", copyDictDeep);
+    defineNative(vm, &vm->dictMethods, "toBool", boolNative); // Defined in util
 }

--- a/c/datatypes/lists.c
+++ b/c/datatypes/lists.c
@@ -231,4 +231,5 @@ void declareListMethods(VM *vm) {
     defineNative(vm, &vm->listMethods, "join", joinListItem);
     defineNative(vm, &vm->listMethods, "copy", copyListShallow);
     defineNative(vm, &vm->listMethods, "deepCopy", copyListDeep);
+    defineNative(vm, &vm->listMethods, "toBool", boolNative); // Defined in util
 }

--- a/c/datatypes/nil.c
+++ b/c/datatypes/nil.c
@@ -12,5 +12,5 @@ static Value toStringNil(VM *vm, int argCount, Value *args) {
 
 void declareNilMethods(VM *vm) {
     defineNative(vm, &vm->nilMethods, "toString", toStringNil);
-    defineNative(vm, &vm->setMethods, "toBool", boolNative); // Defined in util
+    defineNative(vm, &vm->nilMethods, "toBool", boolNative); // Defined in util
 }

--- a/c/datatypes/nil.c
+++ b/c/datatypes/nil.c
@@ -12,4 +12,5 @@ static Value toStringNil(VM *vm, int argCount, Value *args) {
 
 void declareNilMethods(VM *vm) {
     defineNative(vm, &vm->nilMethods, "toString", toStringNil);
+    defineNative(vm, &vm->setMethods, "toBool", boolNative); // Defined in util
 }

--- a/c/datatypes/number.c
+++ b/c/datatypes/number.c
@@ -16,4 +16,5 @@ static Value toStringNumber(VM *vm, int argCount, Value *args) {
 
 void declareNumberMethods(VM *vm) {
     defineNative(vm, &vm->numberMethods, "toString", toStringNumber);
+    defineNative(vm, &vm->numberMethods, "toBool", boolNative); // Defined in util
 }

--- a/c/datatypes/sets.c
+++ b/c/datatypes/sets.c
@@ -30,6 +30,10 @@ static Value addSetItem(VM *vm, int argCount, Value *args) {
         return EMPTY_VAL;
     }
 
+    if (!isValidKey(args[1])) {
+        runtimeError(vm, "Set value must be an immutable type");
+        return EMPTY_VAL;
+    }
 
     ObjSet *set = AS_SET(args[0]);
     setInsert(vm, set, args[1]);
@@ -70,5 +74,6 @@ void declareSetMethods(VM *vm) {
     defineNative(vm, &vm->setMethods, "add", addSetItem);
     defineNative(vm, &vm->setMethods, "remove", removeSetItem);
     defineNative(vm, &vm->setMethods, "contains", containsSetItem);
+    defineNative(vm, &vm->setMethods, "toBool", boolNative); // Defined in util
 }
 

--- a/c/datatypes/strings.c
+++ b/c/datatypes/strings.c
@@ -452,4 +452,5 @@ void declareStringMethods(VM *vm) {
     defineNative(vm, &vm->stringMethods, "rightStrip", rightStripString);
     defineNative(vm, &vm->stringMethods, "strip", stripString);
     defineNative(vm, &vm->stringMethods, "count", countString);
+    defineNative(vm, &vm->stringMethods, "toBool", boolNative); // Defined in util
 }

--- a/c/natives.c
+++ b/c/natives.c
@@ -59,15 +59,6 @@ static Value setNative(VM *vm, int argCount, Value *args) {
     return OBJ_VAL(initSet(vm));
 }
 
-static Value boolNative(VM *vm, int argCount, Value *args) {
-    if (argCount != 1) {
-        runtimeError(vm, "bool() takes 1 argument (%d given).", argCount);
-        return EMPTY_VAL;
-    }
-
-    return BOOL_VAL(!isFalsey(args[0]));
-}
-
 static Value inputNative(VM *vm, int argCount, Value *args) {
     if (argCount > 1) {
         runtimeError(vm, "input() takes either 0 or 1 arguments (%d given)", argCount);
@@ -167,7 +158,6 @@ static Value isDefinedNative(VM *vm, int argCount, Value *args) {
 
 void defineAllNatives(VM *vm) {
     char *nativeNames[] = {
-            "bool",
             "input",
             "type",
             "set",
@@ -177,7 +167,6 @@ void defineAllNatives(VM *vm) {
     };
 
     NativeFn nativeFunctions[] = {
-            boolNative,
             inputNative,
             typeNative,
             setNative,

--- a/c/util.c
+++ b/c/util.c
@@ -60,3 +60,12 @@ bool isValidKey(Value value) {
 
     return false;
 }
+
+Value boolNative(VM *vm, int argCount, Value *args) {
+    if (argCount != 0) {
+        runtimeError(vm, "bool() takes no arguments (%d given).", argCount);
+        return EMPTY_VAL;
+    }
+
+    return BOOL_VAL(!isFalsey(args[0]));
+}

--- a/c/util.h
+++ b/c/util.h
@@ -11,4 +11,6 @@ void defineNativeProperty(VM *vm, Table *table, const char *name, Value value);
 
 bool isValidKey(Value value);
 
+Value boolNative(VM *vm, int argCount, Value *args);
+
 #endif //dictu_util_h

--- a/c/value.c
+++ b/c/value.c
@@ -55,6 +55,12 @@ static uint32_t hashObject(Obj* object) {
 
         // Should never get here
         default: {
+#ifdef DEBUG_PRINT_CODE
+            printf("Object: ");
+            printValue(OBJ_VAL(object));
+            printf(" not hashable!\n");
+            exit(1);
+#endif
             return -1;
         }
     }

--- a/docs/docs/built-ins.md
+++ b/docs/docs/built-ins.md
@@ -49,17 +49,6 @@ type(true); // "bool"
 type([]); // "list"
 ```
 
-### bool(value)
-
-Converts a given value to the boolean value.
-
-```js
-bool(0); // false
-bool(""); // false
-bool(1); // true
-bool("some string"); // true
-```
-
 ### assert(boolean)
 
 Raise a runtime error if the given boolean is not true.

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -84,7 +84,7 @@ Returns the length of the given list.
 
 ### list.toBool()
 
-Converts a list to a boolean. A list is a "truthy" value with it has a length greater than 1.
+Converts a list to a boolean. A list is a "truthy" value when it has a length greater than 0.
 
 ```js
 [].toBool(); // false
@@ -208,7 +208,7 @@ Converts a dictionary to a string.
 
 ### dict.toBool()
 
-Converts a dictionary to a boolean. A dictionary is a "truthy" value with it has a length greater than 1.
+Converts a dictionary to a boolean. A dictionary is a "truthy" value when it has a length greater than 0.
 
 ```js
 var x = {};
@@ -285,7 +285,7 @@ set_b.toString(); // '{2, 1}'
 
 ### set.toBool()
 
-Converts a set to a boolean. A set is a "truthy" value with it has a length greater than 1.
+Converts a set to a boolean. A set is a "truthy" value when it has a length greater than 0.
 
 ```js
 var x = set();

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -67,7 +67,8 @@ myList + [13]; // [10, 11, 12, 13]
 ```
 
 ### list.toString()
-Converts a given list to a string.
+
+Converts a list to a string.
 
 ```js
 ["1", 11].toString();        // ['1', 11]
@@ -79,6 +80,16 @@ Returns the length of the given list.
 
 ```js
 [1, 2, 3].len(); // 3
+```
+
+### list.toBool()
+
+Converts a list to a boolean. A list is a "truthy" value with it has a length greater than 1.
+
+```js
+[].toBool(); // false
+[1].toBool(); // true
+[[]].toBool(); // true
 ```
 
 ### list.contains(value)
@@ -188,11 +199,23 @@ var myDict["key2"] = nil; // {"key": false, "key1": true, "key3": nil}
 ```
 
 ### dict.toString()
-Converts a given dictionary to a string.
+Converts a dictionary to a string.
 
 ```js
 {"1": 1, 1: "1"}.toString(); // '{"1": 1, 1: "1"}'
 {"1": {1: "1", "1": 1}, 1: "1"}.toString(); // '{"1": {"1": 1, 1: "1"}, 1: "1"}'
+```
+
+### dict.toBool()
+
+Converts a dictionary to a boolean. A dictionary is a "truthy" value with it has a length greater than 1.
+
+```js
+var x = {};
+
+x.toBool(); // false
+x["test"] = 1;
+x.toBool(); // true
 ```
 
 ### dict.len()
@@ -237,7 +260,7 @@ var myDict2 = myDict.deepCopy(); // Deep copy
 
 ## Sets
 
-Sets are an unordered collection of unique hashable values. Currently Dictu requires that the hashable value be a string.
+Sets are an unordered collection of unique hashable values. Set values must be of type string, number, boolean or nil.
 
 ```js
 var mySet = set();
@@ -254,11 +277,22 @@ set_a.add("two");
 
 var set_b = set();
 set_b.add(1);
-set_b.add(set_a);
 set_b.add(2);
 
 set_a.toString(); // '{"two", "one"}');
-set_b.toString(); // '{2, 1, {"two", "one"}}'
+set_b.toString(); // '{2, 1}'
+```
+
+### set.toBool()
+
+Converts a set to a boolean. A set is a "truthy" value with it has a length greater than 1.
+
+```js
+var x = set();
+
+x.toBool(); // false
+x.add("test");
+x.toBool(); // true
 ```
 
 ### set.len()

--- a/docs/docs/strings.md
+++ b/docs/docs/strings.md
@@ -84,6 +84,15 @@ Converts a string to number.
 "10".toNumber(); // 10
 ```
 
+### string.toBool()
+
+Converts a string to a boolean. Strings are "truthy" when they have a length greater than 1.
+
+```py
+"".toBool(); // false
+"false".toBool(); // true
+```
+
 ### string.upper()
 
 To make all characters within a string uppercase, use the `.upper()` method.

--- a/docs/docs/variables.md
+++ b/docs/docs/variables.md
@@ -88,7 +88,8 @@ someSet.toString();
 ### value.toBool()
 
 You can convert values into booleans with the toBool method. This is based on whether the
-value is "truthy" or not. A value is "truthy" if the length is greater than 0.
+value is "truthy" or not. A "truthy" value is a value which has a length greater than 0
+or is not 0 when checking number types. `nil` is always false.
 
 ```js
 "".toBool(); // false

--- a/docs/docs/variables.md
+++ b/docs/docs/variables.md
@@ -72,6 +72,8 @@ print(a, b, c); // nil, 10, 'hello!'
 
 ## Casting
 
+### value.toString()
+
 You can convert values into strings with the toString() method.
 
 ```js
@@ -81,4 +83,22 @@ nil.toString();
 someDict.toString();
 someList.toString();
 someSet.toString();
+```
+
+### value.toBool()
+
+You can convert values into booleans with the toBool method. This is based on whether the
+value is "truthy" or not. A value is "truthy" if the length is greater than 0.
+
+```js
+"".toBool(); // false
+"test".toBool(); // true
+"false".toBool(); // true
+
+0.toBool(); // false
+10.toBool(); // true
+
+[].toBool(); // false
+[1].toBool(); // true
+[[]].toBool(); // true
 ```

--- a/tests/dicts/import.du
+++ b/tests/dicts/import.du
@@ -11,3 +11,4 @@ import "tests/dicts/remove.du";
 import "tests/dicts/copy.du";
 import "tests/dicts/len.du";
 import "tests/dicts/toString.du";
+import "tests/dicts/toBool.du";

--- a/tests/dicts/toBool.du
+++ b/tests/dicts/toBool.du
@@ -1,0 +1,15 @@
+/**
+ * toBool.du
+ *
+ * Testing the dict.toBool() method
+ *
+ * .toBool() returns the boolean representation of a dict
+ */
+
+var x = {};
+
+assert(x.toBool() == false);
+x["test"] = 10;
+assert(x.toBool() == true);
+x.remove("test");
+assert(x.toBool() == false);

--- a/tests/dicts/toString.du
+++ b/tests/dicts/toString.du
@@ -6,7 +6,5 @@
  * .toString() returns the string representation of a dict
  */
 
-/* FIX: inconsistency with the quotes */
-
 assert({"1": 1, 1: "1"}.toString() == '{"1": 1, 1: "1"}');
 assert({"1": {1: "1", "1": 1}, 1: "1"}.toString() == '{"1": {"1": 1, 1: "1"}, 1: "1"}');

--- a/tests/lists/import.du
+++ b/tests/lists/import.du
@@ -14,3 +14,4 @@ import "tests/lists/slicing.du";
 import "tests/lists/join.du";
 import "tests/lists/len.du";
 import "tests/lists/toString.du";
+import "tests/lists/toBool.du";

--- a/tests/lists/toBool.du
+++ b/tests/lists/toBool.du
@@ -1,0 +1,18 @@
+/**
+ * toBool.du
+ *
+ * Testing the list.toBool() method
+ *
+ * .toBool() returns the boolean representation of a list
+ */
+
+assert(["1", 11].toBool() == true);
+assert([].toBool() == false);
+
+var myList = [];
+
+assert(myList.toBool() == false);
+myList.push(10);
+assert(myList.toBool() == true);
+myList.pop();
+assert(myList.toBool() == false);

--- a/tests/nil/import.du
+++ b/tests/nil/import.du
@@ -5,3 +5,4 @@
 */
 
 import "tests/nil/toString.du";
+import "tests/nil/toBool.du";

--- a/tests/nil/toBool.du
+++ b/tests/nil/toBool.du
@@ -1,0 +1,9 @@
+/**
+ * toBool.du
+ *
+ * Testing the nil.toBool() method
+ *
+ * .toBool() returns the boolean representation of nil (always false)
+ */
+
+assert(nil.toBool() == false);

--- a/tests/number/import.du
+++ b/tests/number/import.du
@@ -5,3 +5,4 @@
 */
 
 import "tests/number/toString.du";
+import "tests/number/toBool.du";

--- a/tests/number/toBool.du
+++ b/tests/number/toBool.du
@@ -1,0 +1,11 @@
+/**
+ * toBool.du
+ *
+ * Testing the number.toBool() method
+ *
+ * .toBool() returns the boolean representation of a number
+ */
+
+assert(1.toBool() == true);
+assert(0.toBool() == false);
+assert(11.1.toBool() == true);

--- a/tests/sets/import.du
+++ b/tests/sets/import.du
@@ -11,3 +11,4 @@ import "tests/sets/add.du";
 import "tests/sets/remove.du";
 import "tests/sets/len.du";
 import "tests/sets/toString.du";
+import "tests/sets/toBool.du";

--- a/tests/sets/toBool.du
+++ b/tests/sets/toBool.du
@@ -1,0 +1,16 @@
+/**
+ * toBool.du
+ *
+ * Testing the set.toBool() method
+ *
+ * .toBool() returns the boolean representation of a set
+ */
+
+var set_a = set();
+assert(set_a.toBool() == false);
+
+set_a.add("one");
+assert(set_a.toBool() == true);
+
+set_a.remove("one");
+assert(set_a.toBool() == false);

--- a/tests/sets/toString.du
+++ b/tests/sets/toString.du
@@ -13,8 +13,7 @@ set_a.add("two");
 
 var set_b = set();
 set_b.add(1);
-set_b.add(set_a);
 set_b.add(2);
 
 assert(set_a.toString() == '{"two", "one"}');
-assert(set_b.toString() == '{2, 1, {"two", "one"}}');
+assert(set_b.toString() == '{2, 1}');

--- a/tests/strings/import.du
+++ b/tests/strings/import.du
@@ -19,3 +19,4 @@ import "tests/strings/count.du";
 import "tests/strings/slicing.du";
 import "tests/strings/len.du";
 import "tests/strings/toNumber.du";
+import "tests/strings/toBool.du";

--- a/tests/strings/toBool.du
+++ b/tests/strings/toBool.du
@@ -1,0 +1,10 @@
+/**
+* toBool.du
+*
+* Testing the str.toBool() method
+*
+* .toNumber() converts a string to a boolean
+*/
+
+assert("10".toBool() == true);
+assert("".toBool() == false);


### PR DESCRIPTION
# toBool
## Summary
This PR adds the native `toBool` on value types. This converts a value into a boolean based on whether the value is "truthy" or not. A "truthy" value is a value which has a length greater than 0 or is not 0 when checking number types. `nil` is always false.

This PR also fixes an issue where sets could have any value type added to them, this is not allowed as there are only a certain amount of hashing algorithms for certain value types. 