### PR TITLE
Do not raise an error in setCWD() if the operation is not successful.

### DIFF
--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -15,12 +15,7 @@ static Value setCWDNative(VM *vm, int argCount, Value *args) {
 
     int retval = chdir(dir);
 
-    if (retval != 0) {
-        runtimeError(vm, "Error setting current directory");
-        return EMPTY_VAL;
-    }
-
-    return NIL_VAL;
+    return NUMBER_VAL(retval == 0 ? OK : NOTOK);
 }
 
 static Value getCWDNative(VM *vm, int argCount, Value *args) {

--- a/c/vm.h
+++ b/c/vm.h
@@ -59,6 +59,9 @@ typedef enum {
 
 // extern VM vm;
 
+#define OK     0
+#define NOTOK -1
+
 VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]);
 
 void freeVM(VM *vm);

--- a/docs/docs/system.md
+++ b/docs/docs/system.md
@@ -32,7 +32,7 @@ System.getCWD(); // '/Some/Path/To/A/Directory'
 
 ### System.setCWD()
 
-Set current working directory of the Dictu process. Returns 0 uppon success and -1 otherwise.
+Set current working directory of the Dictu process. Returns 0 upon success and -1 otherwise.
 
 ```js
 if (System.setCWD('/') == -1) {

--- a/docs/docs/system.md
+++ b/docs/docs/system.md
@@ -32,10 +32,12 @@ System.getCWD(); // '/Some/Path/To/A/Directory'
 
 ### System.setCWD()
 
-Set current working directory of the Dictu process. Raises a runtime error if it is unsuccessful.
+Set current working directory of the Dictu process. Returns 0 uppon success and -1 otherwise.
 
 ```js
-System.setCWD('/');
+if (System.setCWD('/') == -1) {
+  print ("failed to change directory");
+}
 ```
 
 ### System.sleep(number)

--- a/tests/system/setCWD.du
+++ b/tests/system/setCWD.du
@@ -9,7 +9,7 @@
 var cwd = System.getCWD();
 assert(type(cwd) == 'string');
 assert(cwd.len() > 0);
-System.setCWD("/");
+assert(System.setCWD("/") == 0);
 assert(System.getCWD() == "/");
-System.setCWD(cwd);
+assert(System.setCWD(cwd) == 0);
 assert(System.getCWD() == cwd);

--- a/tests/system/setCWD.du
+++ b/tests/system/setCWD.du
@@ -13,3 +13,6 @@ assert(System.setCWD("/") == 0);
 assert(System.getCWD() == "/");
 assert(System.setCWD(cwd) == 0);
 assert(System.getCWD() == cwd);
+
+assert(System.setCWD("/some/directory/that/doesnt/exist") == -1);
+assert(System.getCWD() == cwd);


### PR DESCRIPTION
Mimic chdir() and libc conventions and return 0 uppon success or -1 otherwise.
Define those values as OK and NOTOK respectively in vm.h.