### PR TITLE
Hash tables

### DIFF
--- a/c/memory.c
+++ b/c/memory.c
@@ -311,7 +311,7 @@ void collectGarbage(VM *vm) {
     }
 
     // Delete unused interned strings.
-    tableRemoveWhite(&vm->strings);
+    tableRemoveWhite(vm, &vm->strings);
 
     // Collect the white objects.
     Obj **object = &vm->objects;

--- a/c/object.h
+++ b/c/object.h
@@ -95,6 +95,7 @@ struct sObjList {
 typedef struct {
     Value key;
     Value value;
+    uint32_t psl;
 } DictItem;
 
 struct sObjDict {

--- a/c/table.c
+++ b/c/table.c
@@ -19,64 +19,108 @@ void freeTable(VM *vm, Table *table) {
     initTable(table);
 }
 
-static Entry *findEntry(Entry *entries, int capacityMask,
-                        ObjString *key) {
-    uint32_t index = key->hash & capacityMask;
-    Entry *tombstone = NULL;
-
-    for (;;) {
-        Entry *entry = &entries[index];
-
-        if (entry->key == NULL) {
-            if (IS_NIL(entry->value)) {
-                // Empty entry.
-                return tombstone != NULL ? tombstone : entry;
-            } else {
-                // We found a tombstone.
-                if (tombstone == NULL) tombstone = entry;
-            }
-        } else if (entry->key == key) {
-            // We found the key.
-            return entry;
-        }
-
-        index = (index + 1) & capacityMask;
-    }
-}
+//static Entry *findEntry(Entry *entries, int capacityMask,
+//                        ObjString *key) {
+//    uint32_t index = key->hash & capacityMask;
+//    Entry *tombstone = NULL;
+//
+//    for (;;) {
+//        Entry *entry = &entries[index];
+//
+//        if (entry->key == NULL) {
+//            if (IS_NIL(entry->value)) {
+//                // Empty entry.
+//                return tombstone != NULL ? tombstone : entry;
+//            } else {
+//                // We found a tombstone.
+//                if (tombstone == NULL) tombstone = entry;
+//            }
+//        } else if (entry->key == key) {
+//            // We found the key.
+//            return entry;
+//        }
+//
+//        index = (index + 1) & capacityMask;
+//    }
+//}
 
 bool tableGet(Table *table, ObjString *key, Value *value) {
     if (table->count == 0) return false;
 
-    Entry *entry = findEntry(table->entries, table->capacityMask, key);
-    if (entry->key == NULL) return false;
+    Entry *entry;
+    uint32_t index = key->hash & table->capacityMask;
+    uint32_t psl = 0;
+
+    for (;;) {
+        entry = &table->entries[index];
+
+        if (entry->key == NULL || psl > entry->psl) {
+            return false;
+        }
+
+        if (entry->key == key) {
+            break;
+        }
+
+        index = (index + 1) & table->capacityMask;
+        psl++;
+    }
 
     *value = entry->value;
     return true;
 }
+
+//bool tableGet(Table *table, ObjString *key, Value *value) {
+//    if (table->count == 0) return false;
+//
+//    Entry *entry = findEntry(table->entries, table->capacityMask, key);
+//    if (entry->key == NULL) return false;
+//
+//    *value = entry->value;
+//    return true;
+//}
 
 static void adjustCapacity(VM *vm, Table *table, int capacityMask) {
     Entry *entries = ALLOCATE(vm, Entry, capacityMask + 1);
     for (int i = 0; i <= capacityMask; i++) {
         entries[i].key = NULL;
         entries[i].value = NIL_VAL;
+        entries[i].psl = 0;
     }
+
+    Entry *oldEntries = table->entries;
+    int oldMask = table->capacityMask;
 
     table->count = 0;
-
-    for (int i = 0; i <= table->capacityMask; i++) {
-        Entry *entry = &table->entries[i];
-        if (entry->key == NULL) continue;
-
-        Entry *dest = findEntry(entries, capacityMask, entry->key);
-        dest->key = entry->key;
-        dest->value = entry->value;
-        table->count++;
-    }
-
-    FREE_ARRAY(vm, Entry, table->entries, table->capacityMask + 1);
     table->entries = entries;
     table->capacityMask = capacityMask;
+
+    for (int i = 0; i <= oldMask; i++) {
+        Entry *entry = &oldEntries[i];
+        if (entry->key == NULL) continue;
+
+        tableSet(vm, table, entry->key, entry->value);
+    }
+
+    FREE_ARRAY(vm, Entry, oldEntries, oldMask + 1);
 }
+
+//bool tableSet(VM *vm, Table *table, ObjString *key, Value value) {
+//    if (table->count + 1 > (table->capacityMask + 1) * TABLE_MAX_LOAD) {
+//        // Figure out the new table size.
+//        int capacityMask = GROW_CAPACITY(table->capacityMask + 1) - 1;
+//        adjustCapacity(vm, table, capacityMask);
+//    }
+//
+//    Entry *entry = findEntry(table->entries, table->capacityMask, key);
+//    bool isNewKey = entry->key == NULL;
+//    entry->key = key;
+//    entry->value = value;
+//
+//    if (isNewKey) table->count++;
+//
+//    return isNewKey;
+//}
 
 bool tableSet(VM *vm, Table *table, ObjString *key, Value value) {
     if (table->count + 1 > (table->capacityMask + 1) * TABLE_MAX_LOAD) {
@@ -85,29 +129,113 @@ bool tableSet(VM *vm, Table *table, ObjString *key, Value value) {
         adjustCapacity(vm, table, capacityMask);
     }
 
-    Entry *entry = findEntry(table->entries, table->capacityMask, key);
-    bool isNewKey = entry->key == NULL;
-    entry->key = key;
-    entry->value = value;
+    uint32_t index = key->hash & table->capacityMask;
+    Entry *bucket;
+    bool isNewKey = false;
 
+    Entry entry;
+    entry.key = key;
+    entry.value = value;
+    entry.psl = 0;
+
+    for (;;) {
+        bucket = &table->entries[index];
+
+        if (bucket->key == NULL) {
+            isNewKey = true;
+            break;
+        } else {
+            if (bucket->key == key) {
+                break;
+            }
+
+            if (entry.psl > bucket->psl) {
+                isNewKey = true;
+                Entry tmp = entry;
+                entry = *bucket;
+                *bucket = tmp;
+            }
+        }
+
+        index = (index + 1) & table->capacityMask;
+        entry.psl++;
+    }
+
+    *bucket = entry;
     if (isNewKey) table->count++;
-
     return isNewKey;
 }
 
-bool tableDelete(Table *table, ObjString *key) {
+bool tableDelete(VM *vm, Table *table, ObjString *key) {
     if (table->count == 0) return false;
 
-    Entry *entry = findEntry(table->entries, table->capacityMask, key);
-    if (entry->key == NULL) return false;
+    int capacityMask = table->capacityMask;
+    uint32_t index = key->hash & table->capacityMask;
+    uint32_t psl = 0;
+    Entry *entry;
 
-    // Place a tombstone in the entry.
+    for (;;) {
+        entry = &table->entries[index];
+
+        if (entry->key == NULL || psl > entry->psl) {
+            return false;
+        }
+
+        if (entry->key == key) {
+            break;
+        }
+
+        index = (index + 1) & capacityMask;
+        psl++;
+    }
+
     table->count--;
-    entry->key = NULL;
-    entry->value = BOOL_VAL(true);
+
+    for (;;) {
+        Entry *nextEntry;
+        entry->key = NULL;
+        entry->value = NIL_VAL;
+        entry->psl = 0;
+
+        index = (index + 1) & capacityMask;
+        nextEntry = &table->entries[index];
+
+        /*
+         * Stop if we reach an empty bucket or hit a key which
+         * is in its base (original) location.
+         */
+        if (nextEntry->key == NULL || nextEntry->psl == 0) {
+            break;
+        }
+
+        nextEntry->psl--;
+        *entry = *nextEntry;
+        entry = nextEntry;
+    }
+
+    // TODO: Add constant for table load factor
+    if (table->count - 1 < table->capacityMask * 0.35) {
+        // Figure out the new table size.
+        capacityMask = SHRINK_CAPACITY(table->capacityMask);
+        adjustCapacity(vm, table, capacityMask);
+    }
 
     return true;
 }
+
+//bool tableDelete(Table *table, ObjString *key) {
+//    if (table->count == 0) return false;
+//
+//    Entry *entry = findEntry(table->entries, table->capacityMask, key);
+//    if (entry->key == NULL) return false;
+//
+//    // Place a tombstone in the entry.
+//    table->count--;
+//    entry->key = NULL;
+//    entry->value = BOOL_VAL(true);
+//
+//    return true;
+//}
 
 void tableAddAll(VM *vm, Table *from, Table *to) {
     for (int i = 0; i <= from->capacityMask; i++) {
@@ -128,29 +256,48 @@ ObjString *tableFindString(Table *table, const char *chars, int length,
     // basic linear probing.
 
     uint32_t index = hash & table->capacityMask;
+    uint32_t psl = 0;
 
     for (;;) {
         Entry *entry = &table->entries[index];
 
-        if (entry->key == NULL) {
-            if (IS_NIL(entry->value)) return NULL;
-        } else if (entry->key->length == length &&
+        if (entry->key == NULL || psl > entry->psl) {
+            return NULL;
+        }
+
+        if (entry->key->length == length &&
             entry->key->hash == hash &&
             memcmp(entry->key->chars, chars, length) == 0) {
             // We found it.
             return entry->key;
         }
 
-        // Try the next slot.
         index = (index + 1) & table->capacityMask;
+        psl++;
     }
+
+//    for (;;) {
+//        Entry *entry = &table->entries[index];
+//
+//        if (entry->key == NULL) {
+//            if (IS_NIL(entry->value)) return NULL;
+//        } else if (entry->key->length == length &&
+//            entry->key->hash == hash &&
+//            memcmp(entry->key->chars, chars, length) == 0) {
+//            // We found it.
+//            return entry->key;
+//        }
+//
+//        // Try the next slot.
+//        index = (index + 1) & table->capacityMask;
+//    }
 }
 
-void tableRemoveWhite(Table *table) {
+void tableRemoveWhite(VM *vm, Table *table) {
     for (int i = 0; i <= table->capacityMask; i++) {
         Entry *entry = &table->entries[i];
         if (entry->key != NULL && !entry->key->obj.isDark) {
-            tableDelete(table, entry->key);
+            tableDelete(vm, table, entry->key);
         }
     }
 }

--- a/c/table.c
+++ b/c/table.c
@@ -1,8 +1,6 @@
-#include <stdlib.h>
 #include <string.h>
 
 #include "memory.h"
-#include "object.h"
 #include "table.h"
 #include "value.h"
 
@@ -18,31 +16,6 @@ void freeTable(VM *vm, Table *table) {
     FREE_ARRAY(vm, Entry, table->entries, table->capacityMask + 1);
     initTable(table);
 }
-
-//static Entry *findEntry(Entry *entries, int capacityMask,
-//                        ObjString *key) {
-//    uint32_t index = key->hash & capacityMask;
-//    Entry *tombstone = NULL;
-//
-//    for (;;) {
-//        Entry *entry = &entries[index];
-//
-//        if (entry->key == NULL) {
-//            if (IS_NIL(entry->value)) {
-//                // Empty entry.
-//                return tombstone != NULL ? tombstone : entry;
-//            } else {
-//                // We found a tombstone.
-//                if (tombstone == NULL) tombstone = entry;
-//            }
-//        } else if (entry->key == key) {
-//            // We found the key.
-//            return entry;
-//        }
-//
-//        index = (index + 1) & capacityMask;
-//    }
-//}
 
 bool tableGet(Table *table, ObjString *key, Value *value) {
     if (table->count == 0) return false;
@@ -70,16 +43,6 @@ bool tableGet(Table *table, ObjString *key, Value *value) {
     return true;
 }
 
-//bool tableGet(Table *table, ObjString *key, Value *value) {
-//    if (table->count == 0) return false;
-//
-//    Entry *entry = findEntry(table->entries, table->capacityMask, key);
-//    if (entry->key == NULL) return false;
-//
-//    *value = entry->value;
-//    return true;
-//}
-
 static void adjustCapacity(VM *vm, Table *table, int capacityMask) {
     Entry *entries = ALLOCATE(vm, Entry, capacityMask + 1);
     for (int i = 0; i <= capacityMask; i++) {
@@ -104,23 +67,6 @@ static void adjustCapacity(VM *vm, Table *table, int capacityMask) {
 
     FREE_ARRAY(vm, Entry, oldEntries, oldMask + 1);
 }
-
-//bool tableSet(VM *vm, Table *table, ObjString *key, Value value) {
-//    if (table->count + 1 > (table->capacityMask + 1) * TABLE_MAX_LOAD) {
-//        // Figure out the new table size.
-//        int capacityMask = GROW_CAPACITY(table->capacityMask + 1) - 1;
-//        adjustCapacity(vm, table, capacityMask);
-//    }
-//
-//    Entry *entry = findEntry(table->entries, table->capacityMask, key);
-//    bool isNewKey = entry->key == NULL;
-//    entry->key = key;
-//    entry->value = value;
-//
-//    if (isNewKey) table->count++;
-//
-//    return isNewKey;
-//}
 
 bool tableSet(VM *vm, Table *table, ObjString *key, Value value) {
     if (table->count + 1 > (table->capacityMask + 1) * TABLE_MAX_LOAD) {
@@ -223,20 +169,6 @@ bool tableDelete(VM *vm, Table *table, ObjString *key) {
     return true;
 }
 
-//bool tableDelete(Table *table, ObjString *key) {
-//    if (table->count == 0) return false;
-//
-//    Entry *entry = findEntry(table->entries, table->capacityMask, key);
-//    if (entry->key == NULL) return false;
-//
-//    // Place a tombstone in the entry.
-//    table->count--;
-//    entry->key = NULL;
-//    entry->value = BOOL_VAL(true);
-//
-//    return true;
-//}
-
 void tableAddAll(VM *vm, Table *from, Table *to) {
     for (int i = 0; i <= from->capacityMask; i++) {
         Entry *entry = &from->entries[i];
@@ -275,22 +207,6 @@ ObjString *tableFindString(Table *table, const char *chars, int length,
         index = (index + 1) & table->capacityMask;
         psl++;
     }
-
-//    for (;;) {
-//        Entry *entry = &table->entries[index];
-//
-//        if (entry->key == NULL) {
-//            if (IS_NIL(entry->value)) return NULL;
-//        } else if (entry->key->length == length &&
-//            entry->key->hash == hash &&
-//            memcmp(entry->key->chars, chars, length) == 0) {
-//            // We found it.
-//            return entry->key;
-//        }
-//
-//        // Try the next slot.
-//        index = (index + 1) & table->capacityMask;
-//    }
 }
 
 void tableRemoveWhite(VM *vm, Table *table) {

--- a/c/table.h
+++ b/c/table.h
@@ -9,6 +9,7 @@
 typedef struct {
     ObjString *key;
     Value value;
+    uint32_t psl;
 } Entry;
 
 typedef struct {
@@ -25,14 +26,14 @@ bool tableGet(Table *table, ObjString *key, Value *value);
 
 bool tableSet(VM *vm, Table *table, ObjString *key, Value value);
 
-bool tableDelete(Table *table, ObjString *key);
+bool tableDelete(VM *vm, Table *table, ObjString *key);
 
 void tableAddAll(VM *vm, Table *from, Table *to);
 
 ObjString *tableFindString(Table *table, const char *chars, int length,
                            uint32_t hash);
 
-void tableRemoveWhite(Table *table);
+void tableRemoveWhite(VM *vm, Table *table);
 
 void grayTable(VM *vm, Table *table);
 

--- a/c/value.c
+++ b/c/value.c
@@ -33,8 +33,7 @@ void freeValueArray(VM *vm, ValueArray *array) {
     initValueArray(array);
 }
 
-static inline uint32_t hashBits(uint64_t hash)
-{
+static inline uint32_t hashBits(uint64_t hash) {
     // From v8's ComputeLongHash() which in turn cites:
     // Thomas Wang, Integer Hash Functions.
     // http://www.concentric.net/~Ttwang/tech/inthash.htm
@@ -44,13 +43,13 @@ static inline uint32_t hashBits(uint64_t hash)
     hash = hash ^ (hash >> 11);
     hash = hash + (hash << 6);
     hash = hash ^ (hash >> 22);
-    return (uint32_t)(hash & 0x3fffffff);
+    return (uint32_t) (hash & 0x3fffffff);
 }
 
-static uint32_t hashObject(Obj* object) {
+static uint32_t hashObject(Obj *object) {
     switch (object->type) {
         case OBJ_STRING: {
-            return ((ObjString*)object)->hash;
+            return ((ObjString *) object)->hash;
         }
 
             // Should never get here

--- a/c/value.c
+++ b/c/value.c
@@ -53,7 +53,7 @@ static uint32_t hashObject(Obj* object) {
             return ((ObjString*)object)->hash;
         }
 
-        // Should never get here
+            // Should never get here
         default: {
 #ifdef DEBUG_PRINT_CODE
             printf("Object: ");
@@ -74,36 +74,27 @@ static uint32_t hashValue(Value value) {
     return hashBits(value);
 }
 
-static DictItem *findDictEntry(DictItem *entries, int capacityMask,
-                           Value key) {
-    uint32_t index = hashValue(key) & capacityMask;
-    DictItem *tombstone = NULL;
-
-    for (;;) {
-        DictItem *entry = &entries[index];
-
-        if (IS_EMPTY(entry->key)) {
-            if (IS_NIL(entry->value)) {
-                // Empty entry.
-                return tombstone != NULL ? tombstone : entry;
-            } else {
-                // We found a tombstone.
-                if (tombstone == NULL) tombstone = entry;
-            }
-        } else if (valuesEqual(key, entry->key)) {
-            // We found the key.
-            return entry;
-        }
-
-        index = (index + 1) & capacityMask;
-    }
-}
-
 bool dictGet(ObjDict *dict, Value key, Value *value) {
     if (dict->count == 0) return false;
 
-    DictItem *entry = findDictEntry(dict->entries, dict->capacityMask, key);
-    if (IS_EMPTY(entry->key)) return false;
+    DictItem *entry;
+    uint32_t index = hashValue(key) & dict->capacityMask;
+    uint32_t psl = 0;
+
+    for (;;) {
+        entry = &dict->entries[index];
+
+        if (IS_EMPTY(entry->key) || psl > entry->psl) {
+            return false;
+        }
+
+        if (valuesEqual(key, entry->key)) {
+            break;
+        }
+
+        index = (index + 1) & dict->capacityMask;
+        psl++;
+    }
 
     *value = entry->value;
     return true;
@@ -114,23 +105,24 @@ static void adjustDictCapacity(VM *vm, ObjDict *dict, int capacityMask) {
     for (int i = 0; i <= capacityMask; i++) {
         entries[i].key = EMPTY_VAL;
         entries[i].value = NIL_VAL;
+        entries[i].psl = 0;
     }
+
+    DictItem *oldEntries = dict->entries;
+    int oldMask = dict->capacityMask;
 
     dict->count = 0;
-
-    for (int i = 0; i <= dict->capacityMask; i++) {
-        DictItem *entry = &dict->entries[i];
-        if (IS_EMPTY(entry->key)) continue;
-
-        DictItem *dest = findDictEntry(entries, capacityMask, entry->key);
-        dest->key = entry->key;
-        dest->value = entry->value;
-        dict->count++;
-    }
-
-    FREE_ARRAY(vm, DictItem, dict->entries, dict->capacityMask + 1);
     dict->entries = entries;
     dict->capacityMask = capacityMask;
+
+    for (int i = 0; i <= oldMask; i++) {
+        DictItem *entry = &oldEntries[i];
+        if (IS_EMPTY(entry->key)) continue;
+
+        dictSet(vm, dict, entry->key, entry->value);
+    }
+
+    FREE_ARRAY(vm, DictItem, oldEntries, oldMask + 1);
 }
 
 bool dictSet(VM *vm, ObjDict *dict, Value key, Value value) {
@@ -140,31 +132,92 @@ bool dictSet(VM *vm, ObjDict *dict, Value key, Value value) {
         adjustDictCapacity(vm, dict, capacityMask);
     }
 
-    DictItem *entry = findDictEntry(dict->entries, dict->capacityMask, key);
-    bool isNewKey = IS_EMPTY(entry->key);
+    uint32_t index = hashValue(key) & dict->capacityMask;
+    DictItem *bucket;
+    bool isNewKey = false;
 
-    entry->key = key;
-    entry->value = value;
+    DictItem entry;
+    entry.key = key;
+    entry.value = value;
+    entry.psl = 0;
 
+    for (;;) {
+        bucket = &dict->entries[index];
+
+        if (IS_EMPTY(bucket->key)) {
+            isNewKey = true;
+            break;
+        } else {
+            if (valuesEqual(key, bucket->key)) {
+                break;
+            }
+
+            if (entry.psl > bucket->psl) {
+                isNewKey = true;
+                DictItem tmp = entry;
+                entry = *bucket;
+                *bucket = tmp;
+            }
+        }
+
+        index = (index + 1) & dict->capacityMask;
+        entry.psl++;
+    }
+
+    *bucket = entry;
     if (isNewKey) dict->count++;
-
     return isNewKey;
 }
 
 bool dictDelete(VM *vm, ObjDict *dict, Value key) {
     if (dict->count == 0) return false;
 
-    DictItem *entry = findDictEntry(dict->entries, dict->capacityMask, key);
-    if (IS_EMPTY(entry->key)) return false;
+    int capacityMask = dict->capacityMask;
+    uint32_t index = hashValue(key) & capacityMask;
+    uint32_t psl = 0;
+    DictItem *entry;
 
-    // Place a tombstone in the entry.
+    for (;;) {
+        entry = &dict->entries[index];
+
+        if (IS_EMPTY(entry->key) || psl > entry->psl) {
+            return false;
+        }
+
+        if (valuesEqual(key, entry->key)) {
+            break;
+        }
+
+        index = (index + 1) & capacityMask;
+        psl++;
+    }
+
     dict->count--;
-    entry->key = EMPTY_VAL;
-    entry->value = BOOL_VAL(true);
+
+    for (;;) {
+        DictItem *nextEntry;
+        entry->key = EMPTY_VAL;
+        entry->value = EMPTY_VAL;
+
+        index = (index + 1) & capacityMask;
+        nextEntry = &dict->entries[index];
+
+        /*
+         * Stop if we reach an empty bucket or hit a key which
+         * is in its base (original) location.
+         */
+        if (IS_EMPTY(nextEntry->key) || nextEntry->psl == 0) {
+            break;
+        }
+
+        nextEntry->psl--;
+        *entry = *nextEntry;
+        entry = nextEntry;
+    }
 
     if (dict->count - 1 < dict->capacityMask * TABLE_MIN_LOAD) {
         // Figure out the new table size.
-        int capacityMask = SHRINK_CAPACITY(dict->capacityMask);
+        capacityMask = SHRINK_CAPACITY(dict->capacityMask);
         adjustDictCapacity(vm, dict, capacityMask);
     }
 
@@ -181,7 +234,7 @@ void grayDict(VM *vm, ObjDict *dict) {
 
 
 static SetItem *findSetEntry(SetItem *entries, int capacityMask,
-                           Value value) {
+                             Value value) {
     uint32_t index = hashValue(value) & capacityMask;
     SetItem *tombstone = NULL;
 
@@ -410,7 +463,7 @@ bool valuesEqual(Value a, Value b) {
                 return setComparison(a, b);
             }
 
-            // Pass through
+                // Pass through
             default:
                 break;
         }

--- a/c/vm.c
+++ b/c/vm.c
@@ -761,7 +761,7 @@ static InterpretResult run(VM *vm) {
         CASE_CODE(SET_GLOBAL): {
             ObjString *name = READ_STRING();
             if (tableSet(vm, &vm->globals, name, peek(vm, 0))) {
-                tableDelete(&vm->globals, name);
+                tableDelete(vm, &vm->globals, name);
                 frame->ip = ip;
                 runtimeError(vm, "Undefined variable '%s'.", name->chars);
                 return INTERPRET_RUNTIME_ERROR;

--- a/tests/builtins/__file__.du
+++ b/tests/builtins/__file__.du
@@ -6,4 +6,3 @@
 
 assert(Path.basename(__file__) == "__file__.du");
 assert(Path.dirname(__file__) == "tests/builtins");
-print (__file__);

--- a/tests/dicts/remove.du
+++ b/tests/dicts/remove.du
@@ -32,3 +32,14 @@ assert(myDict == {10.5: 10.5});
 
 myDict.remove(10.5);
 assert(myDict == {});
+
+for (var i = 0; i < 10000; ++i) {
+    myDict[i] = i;
+}
+
+for (var i = 0; i < 10000; ++i) {
+    myDict.remove(i);
+}
+
+assert(myDict.len() == 0);
+assert(myDict == {});


### PR DESCRIPTION
# Hash Tables
Resolves #172 
## Summary
This PR changes the traditional linear scan used in hash tables within the Dictu interpreter to use the [Robin Hood](https://en.wikipedia.org/wiki/Hash_table#Robin_Hood_hashing) hashing collision scheme. Hash tables are such an important part of the VM that squeezing any amount of performance from them could have quite an impact.

## Results
I ran the tests 25,000 times, twice (with the exception of tests that take a while, e.g HTTP tests and System tests) to give a variety of different opcodes to try and give a fair benchmark for testing.
**Note: Results are in seconds**

### Run 1
|                              |Robin Hood|Generic Linear probe|
|-----------------|------------|---------------------|
|Maximum Time:  |0.02224      | 0.014499    |
|Minimum Time:   |0.005705              | 0.006219      |
|Average Time:     |0.00655383659999996              | 0.00702297708000004  |
|Total Time:           |163.845914999999              | 175.574427000001        |

### Run 2

|                              |Robin Hood|Generic Linear probe|
|-----------------|------------|---------------------|
|Maximum Time:  |0.022698      | 0.017939    |
|Minimum Time:   |0.005608       | 0.006162      |
|Average Time:     |0.00645049179999996      | 0.00702297708000004  |
|Total Time:           |161.262294999999              | 176.540442        |

### Summary
For the average run of the test suite, it improved the time by ~0.0005 seconds, which is not a lot, but an improvement nevertheless!