### PR TITLE
Failed toString parsing to return nil rather than 0

### DIFF
--- a/c/datatypes/strings.c
+++ b/c/datatypes/strings.c
@@ -20,7 +20,15 @@ static Value toNumberString(VM *vm, int argCount, Value *args) {
     }
 
     char *numberString = AS_CSTRING(args[0]);
-    double number = strtod(numberString, NULL);
+    char *end;
+    errno = 0;
+
+    double number = strtod(numberString, &end);
+
+    // Failed conversion
+    if (errno != 0 || *end != '\0') {
+        return NIL_VAL;
+    }
 
     return NUMBER_VAL(number);
 }

--- a/c/datatypes/strings.h
+++ b/c/datatypes/strings.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <errno.h>
 
 #include "../common.h"
 #include "../util.h"

--- a/docs/docs/strings.md
+++ b/docs/docs/strings.md
@@ -107,7 +107,7 @@ To make all characters within a string uppercase, use the `.upper()` method.
 
 ### string.toNumber()
 
-Converts a string to number.
+Converts a string to number. If it fails to parse nil is returned.
 
 ```py
 "10.2".toNumber(); // 10.2

--- a/tests/strings/toNumber.du
+++ b/tests/strings/toNumber.du
@@ -7,6 +7,14 @@
  */
 
 assert("10".toNumber() == 10);
+assert("   10".toNumber() == 10);
 assert("10.2".toNumber() == 10.2);
 assert("10.123456".toNumber() == 10.123456);
 assert("1000000".toNumber() == 1000000);
+
+// Test failed parsing
+assert("10  ".toNumber() == nil);
+assert("number".toNumber() == nil);
+assert("10number".toNumber() == nil);
+assert("10number10".toNumber() == nil);
+assert("10..".toNumber() == nil);


### PR DESCRIPTION
# toNumber
## Summary
`str.toNumber()` currently returns 0 on a failed parse, this means there real no way to check if a parse failed programmatically. This PR changes this by returning `nil` on a failed parse. 