### PR TITLE
Lists

### DIFF
--- a/c/datatypes/lists.c
+++ b/c/datatypes/lists.c
@@ -24,6 +24,27 @@ static Value lenList(VM *vm, int argCount, Value *args) {
     return NUMBER_VAL(list->values.count);
 }
 
+static Value extendList(VM *vm, int argCount, Value *args) {
+    if (argCount != 1) {
+        runtimeError(vm, "extend() takes 1 argument (%d given)", argCount);
+        return EMPTY_VAL;
+    }
+
+    if (!IS_LIST(args[1])) {
+        runtimeError(vm, "extend() argument must be a list");
+        return EMPTY_VAL;
+    }
+
+    ObjList *list = AS_LIST(args[0]);
+    ObjList *listArgument = AS_LIST(args[1]);
+
+    for (int i = 0; i < listArgument->values.count; i++) {
+        writeValueArray(vm, &list->values, listArgument->values.values[i]);
+    }
+
+    return NIL_VAL;
+}
+
 static Value pushListItem(VM *vm, int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError(vm, "push() takes 1 argument (%d given)", argCount);
@@ -224,6 +245,7 @@ static Value copyListDeep(VM *vm, int argCount, Value *args) {
 void declareListMethods(VM *vm) {
     defineNative(vm, &vm->listMethods, "toString", toStringList);
     defineNative(vm, &vm->listMethods, "len", lenList);
+    defineNative(vm, &vm->listMethods, "extend", extendList);
     defineNative(vm, &vm->listMethods, "push", pushListItem);
     defineNative(vm, &vm->listMethods, "insert", insertListItem);
     defineNative(vm, &vm->listMethods, "pop", popListItem);

--- a/c/vm.c
+++ b/c/vm.c
@@ -881,20 +881,26 @@ static InterpretResult run(VM *vm) {
                 double a = AS_NUMBER(pop(vm));
                 push(vm, NUMBER_VAL(a + b));
             } else if (IS_LIST(peek(vm, 0)) && IS_LIST(peek(vm, 1))) {
-                Value listToAddValue = peek(vm, 0);
-                Value listValue = peek(vm, 1);
+                ObjList *listOne = AS_LIST(peek(vm, 1));
+                ObjList *listTwo = AS_LIST(peek(vm, 0));
 
-                ObjList *list = AS_LIST(listValue);
-                ObjList *listToAdd = AS_LIST(listToAddValue);
+                ObjList *finalList = initList(vm);
+                push(vm, OBJ_VAL(finalList));
 
-                for (int i = 0; i < listToAdd->values.count; ++i) {
-                    writeValueArray(vm, &list->values, listToAdd->values.values[i]);
+                for (int i = 0; i < listOne->values.count; ++i) {
+                    writeValueArray(vm, &finalList->values, listOne->values.values[i]);
+                }
+
+                for (int i = 0; i < listTwo->values.count; ++i) {
+                    writeValueArray(vm, &finalList->values, listTwo->values.values[i]);
                 }
 
                 pop(vm);
+
+                pop(vm);
                 pop(vm);
 
-                push(vm, NIL_VAL);
+                push(vm, OBJ_VAL(finalList));
             } else {
                 frame->ip = ip;
                 runtimeError(vm, "Unsupported operand types.");

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -74,7 +74,7 @@ myList.insert(11, 1); // [10, 11, 12]
 
 #### + Operator
 
-Using the + operator on lists will extend and mutate the left hand list.
+Using the + operator on lists will join two lists and return a new list.
 It must be used on two values which are both lists.
 
 ```js
@@ -82,6 +82,21 @@ var x = [10];
 
 x + [11, 12];
 print(x); // [10, 11, 12]
+```
+
+#### list.extend(list)
+
+Similar to the + operator however this mutates the list the method is called on rather than returning a new list.
+
+**Note:** values are not copied to the new list, they are just referenced. This means if the value is mutable
+it will mutate in the extended list as well.
+
+```js
+var x = [];
+x.extend([1, 2, 3]);
+print(x); // [1, 2, 3]
+x.extend([1, 2, 3]);
+print(x); // [1, 2, 3, 1, 2, 3]
 ```
 
 ### list.toString()

--- a/tests/lists/extend.du
+++ b/tests/lists/extend.du
@@ -1,0 +1,19 @@
+/**
+ * push.du
+ *
+ * Testing the list.extend() method
+ *
+ * .extend() will insert all the values of one list into another.
+ * Values are not copied, and are merely referenced. So if a list contains
+ * a mutable value it will mutate in the extended list.
+ */
+
+var x = [];
+
+x.extend([1, 2, 3]);
+assert(x.len() == 3);
+assert(x == [1, 2, 3]);
+
+x.extend([1, 2, 3]);
+assert(x.len() == 6);
+assert(x == [1, 2, 3, 1, 2, 3]);

--- a/tests/lists/import.du
+++ b/tests/lists/import.du
@@ -7,6 +7,7 @@
 import "tests/lists/subscript.du";
 import "tests/lists/contains.du";
 import "tests/lists/push.du";
+import "tests/lists/extend.du";
 import "tests/lists/insert.du";
 import "tests/lists/pop.du";
 import "tests/lists/copy.du";
@@ -15,3 +16,4 @@ import "tests/lists/join.du";
 import "tests/lists/len.du";
 import "tests/lists/toString.du";
 import "tests/lists/toBool.du";
+import "tests/lists/plusOperator.du";

--- a/tests/lists/plusOperator.du
+++ b/tests/lists/plusOperator.du
@@ -1,0 +1,16 @@
+/**
+ * plusOperator.du
+ *
+ * Testing the + operator on lists
+ *
+ * + operator joins two lists and returns a new list
+ */
+
+var x = [1, 2];
+assert(x + [3, 4] == [1, 2, 3, 4]);
+
+// Check to ensure original hasn't mutated
+assert(x = [1, 2]);
+
+var y = x + [3, 4];
+assert(y.len() == 4);


### PR DESCRIPTION
# Lists
## Summary
This PR has two changes. Firstly it changes the behaviour of the `+` operator on lists. Currently the + operator mutates the left hand list by adding all the values of the right. Instead of this behaviour a new list is returned rather than the left hand list being mutated.

The second change is the introduction of `.extend()` which is functionally equivalent to the old behaviour of the `+` operator.