### PR TITLE
Allow set creation with values

### DIFF
--- a/c/natives.c
+++ b/c/natives.c
@@ -56,7 +56,15 @@ static Value typeNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value setNative(VM *vm, int argCount, Value *args) {
-    return OBJ_VAL(initSet(vm));
+    ObjSet *set = initSet(vm);
+    push(vm, OBJ_VAL(set));
+
+    for (int i = 0; i < argCount; i++) {
+        setInsert(vm, set, args[i]);
+    }
+    pop(vm);
+
+    return OBJ_VAL(set);
 }
 
 static Value inputNative(VM *vm, int argCount, Value *args) {

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -286,7 +286,8 @@ var myDict2 = myDict.deepCopy(); // Deep copy
 Sets are an unordered collection of unique hashable values. Set values must be of type string, number, boolean or nil.
 
 ```js
-var mySet = set();
+var mySet = set("test", 10);
+print(mySet); // {10, "test"}
 ```
 
 ### set.toString()

--- a/tests/sets/add.du
+++ b/tests/sets/add.du
@@ -52,3 +52,13 @@ anotherSet.add(10);
 anotherSet.add(10);
 
 assert(anotherSet.len() == 1);
+
+var anotherSet = set(10);
+
+anotherSet.add(10);
+anotherSet.add(10);
+anotherSet.add(10);
+anotherSet.add(10);
+anotherSet.add(10);
+
+assert(anotherSet.len() == 1);

--- a/tests/sets/len.du
+++ b/tests/sets/len.du
@@ -17,5 +17,8 @@ assert(mySet.len() == 2);
 mySet.add("great");
 assert(mySet.len() == 3);
 
+var mySet = set(true, false, nil);
+assert(mySet.len() == 3);
+
 
 

--- a/tests/sets/remove.du
+++ b/tests/sets/remove.du
@@ -54,3 +54,44 @@ assert(!mySet.contains(nil));
 
 assert(mySet.contains("is"));
 assert(mySet.contains("great!"));
+
+
+var mySet = set("dictu", "is", "great!", true, false, 10, 10.5, nil);
+
+assert(mySet.contains("dictu"));
+assert(mySet.contains("is"));
+assert(mySet.contains("great!"));
+assert(mySet.contains(true));
+assert(mySet.contains(false));
+assert(mySet.contains(10));
+assert(mySet.contains(10.5));
+assert(mySet.contains(nil));
+
+assert(mySet.len() == 8);
+
+mySet.remove("dictu");
+
+assert(mySet.len() == 7);
+
+assert(!mySet.contains("dictu"));
+assert(mySet.contains("is"));
+assert(mySet.contains("great!"));
+
+
+mySet.remove(true);
+assert(!mySet.contains(true));
+
+mySet.remove(false);
+assert(!mySet.contains(false));
+
+mySet.remove(10);
+assert(!mySet.contains(10));
+
+mySet.remove(10.5);
+assert(!mySet.contains(10.5));
+
+mySet.remove(nil);
+assert(!mySet.contains(nil));
+
+assert(mySet.contains("is"));
+assert(mySet.contains("great!"));

--- a/tests/sets/toBool.du
+++ b/tests/sets/toBool.du
@@ -14,3 +14,12 @@ assert(set_a.toBool() == true);
 
 set_a.remove("one");
 assert(set_a.toBool() == false);
+
+var set_a = set(true, false);
+assert(set_a.toBool() == true);
+
+set_a.remove(true);
+assert(set_a.toBool() == true);
+
+set_a.remove(false);
+assert(set_a.toBool() == false);

--- a/tests/sets/toString.du
+++ b/tests/sets/toString.du
@@ -17,3 +17,6 @@ set_b.add(2);
 
 assert(set_a.toString() == '{"two", "one"}');
 assert(set_b.toString() == '{2, 1}');
+
+var set_a = set("one", 2, 3.3, true, false, nil);
+assert(set_a.toString() == '{2, 3.3, false, true, nil, "one"}');


### PR DESCRIPTION
# Sets
## Summary
Currently a set has no way to be created with initial values leading to something like the following
```
var s = set();
s.add(1);
s.add(2);
s.add(3);
...
```

This PR changes this so any amount of arguments can be passed to set() and it will return a set with these values inside.

```
var s = set(1, 2, 3);
```