### PR TITLE
Return nil when readLine() can read no more

### DIFF
--- a/c/datatypes/files.c
+++ b/c/datatypes/files.c
@@ -109,7 +109,7 @@ static Value readLineFile(VM *vm, int argCount, Value *args) {
         return OBJ_VAL(copyString(vm, line, lineLength));
     }
 
-    return OBJ_VAL(copyString(vm, "", 0));
+    return NIL_VAL;
 }
 
 static Value seekFile(VM *vm, int argCount, Value *args) {

--- a/c/datatypes/files.c
+++ b/c/datatypes/files.c
@@ -105,7 +105,10 @@ static Value readLineFile(VM *vm, int argCount, Value *args) {
     if (fgets(line, 4096, file->file) != NULL) {
         int lineLength = strlen(line);
         // Remove newline char
-        line[lineLength - 1] = '\0';
+        if (line[lineLength - 1] == '\n') {
+            lineLength--;
+            line[lineLength] = '\0';
+        }
         return OBJ_VAL(copyString(vm, line, lineLength));
     }
 

--- a/docs/docs/files.md
+++ b/docs/docs/files.md
@@ -63,8 +63,8 @@ with("test.txt", "r") {
 // Read a file line by line
 with("test.txt", "r") {
     var line;
-    // When you reach the end of the file, an empty string is returned, which is a falsey value
-    while((line = file.readLine())) {
+    // When you reach the end of the file, nil is returned
+    while((line = file.readLine()) != nil) {
         print(line);
     }
 }

--- a/tests/files/import.du
+++ b/tests/files/import.du
@@ -1,0 +1,7 @@
+/**
+ * import.du
+ *
+ * General import file for all the file tests
+ */
+
+import "tests/files/read.du";

--- a/tests/files/import.du
+++ b/tests/files/import.du
@@ -4,4 +4,4 @@
  * General import file for all the file tests
  */
 
-import "tests/files/read.du";
+import "tests/files/readLine.du";

--- a/tests/files/read.du
+++ b/tests/files/read.du
@@ -1,6 +1,13 @@
+/**
+ * read.du
+ *
+ * Testing file reading
+ */
+
 with("tests/files/read.txt", "r") {
     var line;
-     while (line = file.readLine()) {
-         assert(line == "Dictu is great!");
-     }
- }
+    while ((line = file.readLine()) != nil) {
+        // Check readline works with empty lines as well
+        assert(line == "Dictu is great!" or line == "");
+    }
+}

--- a/tests/files/read.txt
+++ b/tests/files/read.txt
@@ -3,6 +3,8 @@ Dictu is great!
 Dictu is great!
 Dictu is great!
 Dictu is great!
+
+
 Dictu is great!
 Dictu is great!
 Dictu is great!

--- a/tests/files/readLine.du
+++ b/tests/files/readLine.du
@@ -1,7 +1,7 @@
 /**
- * read.du
+ * readLine.du
  *
- * Testing file reading
+ * Testing file reading with readLine()
  */
 
 with("tests/files/read.txt", "r") {

--- a/tests/runTests.du
+++ b/tests/runTests.du
@@ -10,6 +10,7 @@ import "tests/operators/import.du";
 import "tests/functions/import.du";
 import "tests/classes/import.du";
 import "tests/builtins/import.du";
+import "tests/files/import.du";
 import "tests/maths/import.du";
 import "tests/loops/import.du";
 import "tests/env/import.du";


### PR DESCRIPTION
# readLine()
## Summary
Currently `readLine()` returns an empty string when the file has finished reading, however there could just be an empty line within the file - this means there's no way to tell if it's finished reading or it's just a new line. This PR changes this to return `nil` when it has finished reading the file which gives a definitive value to check against for file completion.

This PR also fixes a bug where the string being created from `readLine()` had the wrong length and wasn't working correctly if the line did not include a new line character.

It also adds file reading into the test pipeline