### PR TITLE
Suppress the compiler warnings for unused parameters.

### DIFF
--- a/c.make
+++ b/c.make
@@ -5,8 +5,7 @@
 # NAME         Name of the output executable (and object file directory).
 # SOURCE_DIR   Directory where source files and headers are found.
 
-CFLAGS := -Wall -Wextra -Werror -Wno-unused-parameter -fno-strict-aliasing \
-          -Wshadow -Wunused-function -Wunused-macros -fno-strict-aliasing
+CFLAGS := -Wall -Wextra -Werror -Wshadow -Wunused-function -Wunused-macros -fno-strict-aliasing
 LFLAGS := -lm
 
 DISABLE_HTTP := 0

--- a/c/chunk.c
+++ b/c/chunk.c
@@ -5,6 +5,8 @@
 #include "vm.h"
 
 void initChunk(VM *vm, Chunk *chunk) {
+    UNUSED(vm);
+
     chunk->count = 0;
     chunk->capacity = 0;
     chunk->code = NULL;

--- a/c/compiler.c
+++ b/c/compiler.c
@@ -387,6 +387,8 @@ static void declareVariable(Compiler *compiler) {
 }
 
 static uint8_t parseVariable(Compiler *compiler, const char *errorMessage, bool constant) {
+    UNUSED(constant);
+
     consume(compiler, TOKEN_IDENTIFIER, errorMessage);
 
     // If it's a global variable, create a string constant for it.
@@ -434,6 +436,8 @@ static int argumentList(Compiler *compiler) {
 }
 
 static void and_(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     // left operand...
     // OP_JUMP_IF       ------.
     // OP_POP // left operand |
@@ -452,6 +456,8 @@ static void and_(Compiler *compiler, bool canAssign) {
 }
 
 static void binary(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     TokenType operatorType = compiler->parser->previous.type;
 
     ParseRule *rule = getRule(operatorType);
@@ -509,6 +515,8 @@ static void binary(Compiler *compiler, bool canAssign) {
 }
 
 static void call(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     int argCount = argumentList(compiler);
     emitBytes(compiler, OP_CALL, argCount);
 }
@@ -565,6 +573,8 @@ static void dot(Compiler *compiler, bool canAssign) {
 }
 
 static void literal(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     switch (compiler->parser->previous.type) {
         case TOKEN_FALSE:
             emitByte(compiler, OP_FALSE);
@@ -627,6 +637,8 @@ static void beginFunction(Compiler *compiler, Compiler *fnCompiler, FunctionType
 }
 
 static void arrow(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     Compiler fnCompiler;
 
     // Setup function and parse parameters
@@ -646,16 +658,22 @@ static void arrow(Compiler *compiler, bool canAssign) {
 }
 
 static void grouping(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     expression(compiler);
     consume(compiler, TOKEN_RIGHT_PAREN, "Expect ')' after expression.");
 }
 
 static void number(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     double value = strtod(compiler->parser->previous.start, NULL);
     emitConstant(compiler, NUMBER_VAL(value));
 }
 
 static void or_(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     // left operand...
     // OP_JUMP_IF       ---.
     // OP_JUMP          ---+--.
@@ -721,6 +739,8 @@ int parseString(char *string, int length) {
 }
 
 static void rString(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     if (match(compiler, TOKEN_STRING)) {
         Parser *parser = compiler->parser;
         emitConstant(compiler, OBJ_VAL(copyString(parser->vm, parser->previous.start + 1,
@@ -733,6 +753,8 @@ static void rString(Compiler *compiler, bool canAssign) {
 }
 
 static void string(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     Parser *parser = compiler->parser;
 
     char *string = malloc(sizeof(char) * parser->previous.length - 1);
@@ -745,6 +767,8 @@ static void string(Compiler *compiler, bool canAssign) {
 }
 
 static void list(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     emitByte(compiler, OP_NEW_LIST);
 
     do {
@@ -759,6 +783,8 @@ static void list(Compiler *compiler, bool canAssign) {
 }
 
 static void dict(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     emitByte(compiler, OP_NEW_DICT);
 
     do {
@@ -935,6 +961,8 @@ static void pushSuperclass(Compiler *compiler) {
 }
 
 static void super_(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     if (compiler->class == NULL) {
         error(compiler->parser, "Cannot utilise 'super' outside of a class.");
     } else if (!compiler->class->hasSuperclass) {
@@ -961,6 +989,8 @@ static void super_(Compiler *compiler, bool canAssign) {
 }
 
 static void this_(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     if (compiler->class == NULL) {
         error(compiler->parser, "Cannot utilise 'this' outside of a class.");
     } else if (compiler->class->staticMethod) {
@@ -971,6 +1001,8 @@ static void this_(Compiler *compiler, bool canAssign) {
 }
 
 static void static_(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     if (compiler->class == NULL) {
         error(compiler->parser, "Cannot utilise 'static' outside of a class.");
     }
@@ -991,6 +1023,8 @@ static void useStatement(Compiler *compiler) {
 }
 
 static void unary(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     TokenType operatorType = compiler->parser->previous.type;
 
     parsePrecedence(compiler, PREC_UNARY);
@@ -1008,6 +1042,8 @@ static void unary(Compiler *compiler, bool canAssign) {
 }
 
 static void prefix(Compiler *compiler, bool canAssign) {
+    UNUSED(canAssign);
+
     TokenType operatorType = compiler->parser->previous.type;
     Token cur = compiler->parser->current;
     consume(compiler, TOKEN_IDENTIFIER, "Expected variable");

--- a/c/datatypes/nil.c
+++ b/c/datatypes/nil.c
@@ -2,6 +2,8 @@
 #include "../vm.h"
 
 static Value toStringNil(VM *vm, int argCount, Value *args) {
+    UNUSED(args);
+
     if (argCount != 0) {
         runtimeError(vm, "toString() takes no arguments (%d given)", argCount);
         return EMPTY_VAL;

--- a/c/main.c
+++ b/c/main.c
@@ -60,6 +60,8 @@ static bool replCountQuotes(char *line) {
 }
 
 static void repl(VM *vm, int argc, const char *argv[]) {
+    UNUSED(argc); UNUSED(argv);
+
     printf(VERSION);
     char *line;
 
@@ -102,6 +104,8 @@ static void repl(VM *vm, int argc, const char *argv[]) {
 }
 
 static void runFile(VM *vm, int argc, const char *argv[]) {
+    UNUSED(argc);
+
     char *source = readFile(argv[1]);
     InterpretResult result = interpret(vm, source);
     free(source); // [owner]

--- a/c/natives.c
+++ b/c/natives.c
@@ -115,6 +115,8 @@ static Value inputNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value printNative(VM *vm, int argCount, Value *args) {
+    UNUSED(vm);
+
     if (argCount == 0) {
         printf("\n");
         return NIL_VAL;

--- a/c/optionals/jsonParseLib.c
+++ b/c/optionals/jsonParseLib.c
@@ -36,6 +36,8 @@
    #include <stdint.h>
 #endif
 
+#define UNUSED(__x__) (void) __x__
+
 const struct _json_value json_value_none;
 
 #include <stdio.h>
@@ -92,11 +94,15 @@ typedef struct
 
 static void * default_alloc (size_t size, int zero, void * user_data)
 {
+    UNUSED(user_data);
+
     return zero ? calloc (1, size) : malloc (size);
 }
 
 static void default_free (void * ptr, void * user_data)
 {
+    UNUSED(user_data);
+
     free (ptr);
 }
 

--- a/c/optionals/path.h
+++ b/c/optionals/path.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 #ifndef PATH_MAX
-    PATH_MAX = 4096;
+#define PATH_MAX 4096
 #endif
 
 #ifdef _WIN32

--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -1,6 +1,8 @@
 #include "system.h"
 
 static Value getgidNative(VM *vm, int argCount, Value *args) {
+    UNUSED(args);
+
     if (argCount != 0) {
         runtimeError(vm, "getgid() doesn't take any argument (%d given)", argCount);
         return EMPTY_VAL;
@@ -10,6 +12,8 @@ static Value getgidNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value getegidNative(VM *vm, int argCount, Value *args) {
+    UNUSED(args);
+
     if (argCount != 0) {
         runtimeError(vm, "getegid() doesn't take any argument (%d given)", argCount);
         return EMPTY_VAL;
@@ -19,6 +23,8 @@ static Value getegidNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value getuidNative(VM *vm, int argCount, Value *args) {
+    UNUSED(args);
+
     if (argCount != 0) {
         runtimeError(vm, "getuid() doesn't take any argument (%d given)", argCount);
         return EMPTY_VAL;
@@ -28,6 +34,8 @@ static Value getuidNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value geteuidNative(VM *vm, int argCount, Value *args) {
+    UNUSED(args);
+
     if (argCount != 0) {
         runtimeError(vm, "geteuid() doesn't take any argument (%d given)", argCount);
         return EMPTY_VAL;
@@ -37,6 +45,8 @@ static Value geteuidNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value getppidNative(VM *vm, int argCount, Value *args) {
+    UNUSED(args);
+
     if (argCount != 0) {
         runtimeError(vm, "getppid() doesn't take any argument (%d given)", argCount);
         return EMPTY_VAL;
@@ -46,6 +56,8 @@ static Value getppidNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value getpidNative(VM *vm, int argCount, Value *args) {
+    UNUSED(args);
+
     if (argCount != 0) {
         runtimeError(vm, "getpid() doesn't take any argument (%d given)", argCount);
         return EMPTY_VAL;
@@ -154,6 +166,8 @@ static Value setCWDNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value getCWDNative(VM *vm, int argCount, Value *args) {
+    UNUSED(argCount); UNUSED(args);
+
     char cwd[PATH_MAX];
 
     if (getcwd(cwd, sizeof(cwd)) != NULL) {
@@ -166,14 +180,20 @@ static Value getCWDNative(VM *vm, int argCount, Value *args) {
 }
 
 static Value timeNative(VM *vm, int argCount, Value *args) {
+    UNUSED(vm); UNUSED(argCount); UNUSED(args);
+
     return NUMBER_VAL((double) time(NULL));
 }
 
 static Value clockNative(VM *vm, int argCount, Value *args) {
+    UNUSED(vm); UNUSED(argCount); UNUSED(args);
+
     return NUMBER_VAL((double) clock() / CLOCKS_PER_SEC);
 }
 
 static Value collectNative(VM *vm, int argCount, Value *args) {
+    UNUSED(argCount); UNUSED(args);
+
     collectGarbage(vm);
     return NIL_VAL;
 }

--- a/c/vm.h
+++ b/c/vm.h
@@ -63,6 +63,8 @@ typedef enum {
 #define OK     0
 #define NOTOK -1
 
+#define UNUSED(__x__) (void) __x__
+
 VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]);
 
 void freeVM(VM *vm);


### PR DESCRIPTION
# Summary
This PR removes the `-Wno-unused-parameter` compiler flag and adds a new `UNUSED` macro. This will aid in development as it will force the developer to explicitly set a parameter to UNUSED when it is not being used. 