### PR TITLE
Fix strftime() native method.

### DIFF
--- a/c/optionals/datetime.c
+++ b/c/optionals/datetime.c
@@ -62,9 +62,17 @@ static Value strftimeNative(VM *vm, int argCount, Value *args) {
         time(&t);
     }
 
+    ObjString *format = AS_STRING(args[0]);
+
+    /** this is to avoid an eternal loop while calling strftime() below */
+    if (0 == format->length)
+        return OBJ_VAL(copyString(vm, "", 0));
+
+    char *fmt = format->chars;
+
     struct tm tictoc;
-    int len = 100;
-    char buffer[100], *point = buffer;
+    int len = (format->length > 128 ? format->length * 4 : 128);
+    char buffer[len], *point = buffer;
 
     gmtime_r(&t, &tictoc);
 
@@ -73,18 +81,38 @@ static Value strftimeNative(VM *vm, int argCount, Value *args) {
      * not being large enough. In that instance we double the buffer length until
      * there is a big enough buffer.
      */
-    while (strftime(point, sizeof(char) * len, AS_CSTRING(args[0]), &tictoc) == 0) {
-        len *= 2;
-        if (buffer != point)
-            free(point);
 
-        point = malloc(len);
+    /** however is not guaranteed that 0 indicates a failure (`man strftime' says so).
+     * So we might want to catch up the eternal loop, by using a maximum iterator.
+     */
+
+    ObjString *res;
+
+    int max_iterations = 8;  // maximum 65536 bytes with the default 128 len,
+                             // more if the given string is > 128
+    int iterator = 0;
+    while (strftime(point, sizeof(char) * len, fmt, &tictoc) == 0) {
+        if (++iterator > max_iterations) {
+            res = copyString(vm, "", 0);
+            goto theend;
+        }
+
+        len *= 2;
+
+        if (buffer == point)
+            point = malloc (len);
+        else
+            point = realloc (point, len);
+
     }
 
+    res = copyString(vm, point, strlen(point));
+
+theend:
     if (buffer != point)
         free(point);
 
-    return OBJ_VAL(copyString(vm, point, strlen(point)));
+    return OBJ_VAL(res);
 }
 
 static Value strptimeNative(VM *vm, int argCount, Value *args) {

--- a/tests/datetime/strftime.du
+++ b/tests/datetime/strftime.du
@@ -24,3 +24,5 @@ assert(Datetime.strftime("%M", 1577836800) == "00");
 assert(Datetime.strftime("%S", 1577836800) == "00");
 
 assert(Datetime.strftime("%Y-%m-%d %H:%M:%S", 1577836800) == "2020-01-01 00:00:00");
+
+assert(Datetime.strftime("") == ""); // catch up the case of an empty string


### PR DESCRIPTION
Return an empty string when a zero length string is given as an argument. Use a maximum
iterator, to catch up some cases when strftime() returns an empty string in some locales.