### PR TITLE
Reset the module to the function on import end

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,8 @@ jobs:
           rm -rf build
       - name: Make dictu and run tests (HTTP)
         run: |
-          sudo apt-get update && apt-get install -y libcurl4-openssl-dev
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
           make debug
           ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
   test-mac:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           rm -rf build
       - name: Make dictu and run tests (HTTP)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get update && apt-get install -y libcurl4-openssl-dev
           make debug
           ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
   test-mac:

--- a/c/vm.c
+++ b/c/vm.c
@@ -1101,6 +1101,9 @@ static InterpretResult run(VM *vm) {
             } else {
                 setcurrentFile(vm, "", 0);
             }
+
+            vm->lastModule = frame->closure->function->module;
+
             DISPATCH();
         }
 


### PR DESCRIPTION
# Reset the module to the function on import end
## Summary
When an import was importing another file, the pointer to the last module imported was not being reset, this means that the reference to the first import was wrong as it was referencing the second import. This PR fixes this by reseting the pointer to the last module when an import has finished.

Fix an issue with CI/CD process. cURL installation was failing without an update.