### PR TITLE
Point to the correct instruction pointer when disassembling

### DIFF
--- a/c/vm.c
+++ b/c/vm.c
@@ -641,7 +641,7 @@ static InterpretResult run(VM *vm) {
                 }                                                                                 \
                 printf("\n");                                                                     \
                 disassembleInstruction(&frame->closure->function->chunk,                          \
-                        (int) (frame->ip - frame->closure->function->chunk.code));                \
+                        (int) (ip - frame->closure->function->chunk.code));                \
                 goto *dispatchTable[instruction = READ_BYTE()];                                   \
             }                                                                                     \
             while (false)


### PR DESCRIPTION
# Disassembling
Resolves #180 
## Summary
At first look i thought the debug file was out of date as when tracing through the OPCODES the VM was running, it was obvious it was wrong. It turned out to be something else. The ip (instruction pointer, or program counter) was referencing `frame->ip` and not the local `ip` variable.