### PR TITLE
Add missing opcodes and fix issue with dicts

### DIFF
--- a/c/debug.c
+++ b/c/debug.c
@@ -108,7 +108,7 @@ int disassembleInstruction(Chunk *chunk, int offset) {
         case OP_INCREMENT:
             return simpleInstruction("OP_INCREMENT", offset);
         case OP_DECREMENT:
-            return simpleInstruction("OP_INCREMENT", offset);
+            return simpleInstruction("OP_DECREMENT", offset);
         case OP_MULTIPLY:
             return simpleInstruction("OP_MULTIPLY", offset);
         case OP_DIVIDE:
@@ -135,6 +135,8 @@ int disassembleInstruction(Chunk *chunk, int offset) {
             return jumpInstruction("OP_LOOP", -1, chunk, offset);
         case OP_IMPORT:
             return constantInstruction("OP_IMPORT", chunk, offset);
+        case OP_IMPORT_VARIABLE:
+            return simpleInstruction("OP_IMPORT_VARIABLE", offset);
         case OP_IMPORT_END:
             return simpleInstruction("OP_IMPORT_END", offset);
         case OP_NEW_LIST:
@@ -182,6 +184,8 @@ int disassembleInstruction(Chunk *chunk, int offset) {
             return simpleInstruction("OP_CLOSE_UPVALUE", offset);
         case OP_RETURN:
             return simpleInstruction("OP_RETURN", offset);
+        case OP_EMPTY:
+            return simpleInstruction("OP_EMPTY", offset);
         case OP_CLASS:
             return constantInstruction("OP_CLASS", chunk, offset);
         case OP_TRAIT:
@@ -196,6 +200,10 @@ int disassembleInstruction(Chunk *chunk, int offset) {
             return constantInstruction("OP_USE", chunk, offset);
         case OP_OPEN_FILE:
             return constantInstruction("OP_OPEN_FILE", chunk, offset);
+        case OP_CLOSE_FILE:
+            return simpleInstruction("OP_CLOSE_FILE", offset);
+        case OP_BREAK:
+            return simpleInstruction("OP_BREAK", offset);
         default:
             printf("Unknown opcode %d\n", instruction);
             return offset + 1;

--- a/c/object.c
+++ b/c/object.c
@@ -288,9 +288,9 @@ char *dictToString(Value value) {
 
        if (keySize > (size - dictStringLength - 1)) {
            if (keySize > size * 2) {
-               size += keySize * 2;
+               size += keySize * 2 + 4;
            } else {
-               size *= 2;
+               size *= 2 + 4;
            }
 
            char *newB = realloc(dictString, sizeof(char) * size);


### PR DESCRIPTION
# Debug
Resolves #180 
## Summary
This PR adds some missing opcodes to the disassembly function. This also fixes an issue where dictionary keys which were being converted to strings did not malloc enough memory in certain circumstances. 