### PR TITLE
Add dict.keys()

### DIFF
--- a/c/datatypes/dicts.c
+++ b/c/datatypes/dicts.c
@@ -24,6 +24,29 @@ static Value lenDict(VM *vm, int argCount, Value *args) {
     return NUMBER_VAL(dict->count);
 }
 
+static Value keysDict(VM *vm, int argCount, Value *args) {
+    if (argCount != 0) {
+        runtimeError(vm, "keys() takes no arguments (%d given)", argCount);
+        return EMPTY_VAL;
+    }
+
+    ObjDict *dict = AS_DICT(args[0]);
+
+    ObjList *list = initList(vm);
+    push(vm, OBJ_VAL(list));
+
+    for (int i = 0; i < dict->capacityMask + 1; ++i) {
+        if (IS_EMPTY(dict->entries[i].key)) {
+            continue;
+        }
+
+        writeValueArray(vm, &list->values, dict->entries[i].key);
+    }
+
+    pop(vm);
+    return OBJ_VAL(list);
+}
+
 static Value getDictItem(VM *vm, int argCount, Value *args) {
     if (argCount != 1 && argCount != 2) {
         runtimeError(vm, "get() takes 1 or 2 arguments (%d given)", argCount);
@@ -126,6 +149,7 @@ static Value copyDictDeep(VM *vm, int argCount, Value *args) {
 void declareDictMethods(VM *vm) {
     defineNative(vm, &vm->dictMethods, "toString", toStringDict);
     defineNative(vm, &vm->dictMethods, "len", lenDict);
+    defineNative(vm, &vm->dictMethods, "keys", keysDict);
     defineNative(vm, &vm->dictMethods, "get", getDictItem);
     defineNative(vm, &vm->dictMethods, "remove", removeDictItem);
     defineNative(vm, &vm->dictMethods, "exists", dictItemExists);

--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -251,6 +251,16 @@ myDict.get("unknown key", 10); // 10
 myDict.get("unknown key"); // nil
 ```
 
+### dict.keys()
+
+Returns a list of all of the dictionary keys.
+
+```js
+var myDict = {1: 2, "test": 3};
+
+myDict.keys(); // [1, "test"]
+```
+
 ### dict.toString()
 Converts a dictionary to a string.
 

--- a/tests/dicts/import.du
+++ b/tests/dicts/import.du
@@ -5,6 +5,7 @@
 */
 
 import "tests/dicts/subscript.du";
+import "tests/dicts/keys.du";
 import "tests/dicts/get.du";
 import "tests/dicts/exists.du";
 import "tests/dicts/remove.du";

--- a/tests/dicts/keys.du
+++ b/tests/dicts/keys.du
@@ -1,0 +1,16 @@
+/**
+ * keys.du
+ *
+ * Testing the dict.keys() method
+ *
+ * .keys() returns a list of values of all the dictionary keys
+ */
+
+var dict = {"test": 1, 1: 2, true: false, false: true, nil: nil};
+
+// Ensure dict created properly
+assert(dict == {"test": 1, 1: 2, true: false, false: true, nil: nil});
+
+assert(dict.keys().len() == 5);
+assert(type(dict.keys()) == "list");
+assert(dict.keys() == [false, true, nil, 1, "test"]);


### PR DESCRIPTION
# Dict.keys()
## Summary
This adds `.keys()` to dictionaries. This returns a list of all of the dictionary keys. This would be useful, for example, to loop through a dictionary.