### PR TITLE
Add the ability to define class variables

### DIFF
--- a/c/memory.c
+++ b/c/memory.c
@@ -102,6 +102,7 @@ static void blackenObject(VM *vm, Obj *object) {
             grayObject(vm, (Obj *) klass->superclass);
             grayTable(vm, &klass->methods);
             grayTable(vm, &klass->abstractMethods);
+            grayTable(vm, &klass->properties);
             break;
         }
 
@@ -188,6 +189,7 @@ void freeObject(VM *vm, Obj *object) {
             ObjClass *klass = (ObjClass *) object;
             freeTable(vm, &klass->methods);
             freeTable(vm, &klass->abstractMethods);
+            freeTable(vm, &klass->properties);
             FREE(vm, ObjClass, object);
             break;
         }

--- a/c/object.c
+++ b/c/object.c
@@ -59,6 +59,7 @@ ObjClass *newClass(VM *vm, ObjString *name, ObjClass *superclass, ClassType type
     klass->type = type;
     initTable(&klass->abstractMethods);
     initTable(&klass->methods);
+    initTable(&klass->properties);
     return klass;
 }
 

--- a/c/object.h
+++ b/c/object.h
@@ -179,6 +179,7 @@ typedef struct sObjClass {
     struct sObjClass *superclass;
     Table methods;
     Table abstractMethods;
+    Table properties;
     ClassType type;
 } ObjClass;
 

--- a/docs/docs/classes.md
+++ b/docs/docs/classes.md
@@ -178,6 +178,34 @@ myObject.setAttribute("x", 100);
 print(myObject.x); // 100
 ```
 
+## Class variables
+
+A class variable, is a variable that is defined on the class and not the instance. This means that all instances of the class will have access
+to the class variable, and it is also shared across all instances.
+
+```js
+class SomeClass {
+    var classVariable = 10; // This will be shared among all "SomeClass" instances
+
+    init() {
+        this.x = 10; // "x" is set on the instance
+    }
+}
+
+print(SomeClass.classVaraible); // 10
+
+var x = SomeClass();
+var y = SomeClass();
+
+print(x.classVariable); // 10
+print(y.classVariable); // 10
+
+SomeClass.classVaraible = 100;
+
+print(x.classVariable); // 100
+print(y.classVariable); // 100
+```
+
 ## Static methods
 
 Static methods are methods which do not reference an object, and instead belong to a class. If a method is marked as static, `this` is not passed to the object. This means static methods can be invoked without instantiating an object.

--- a/tests/classes/classVariables.du
+++ b/tests/classes/classVariables.du
@@ -1,0 +1,56 @@
+class Test {
+    var x = 10;
+
+    init() {
+        //
+    }
+}
+
+assert(Test.x == 10);
+
+// Class vars are different in that if they are changed on the class they're changed on all instances
+// E.g
+
+var x = Test();
+var y = Test();
+
+// Update class var
+Test.x = 1000;
+
+assert(x.x == 1000);
+assert(y.x == 1000);
+
+
+/**
+ * Ensure inherited classes work
+ */
+class BaseClass {
+    var x = 10;
+}
+
+class Common < BaseClass {}
+
+assert(Common.x == 10);
+assert(Common().x == 10);
+
+class AnotherClass < Common {}
+
+assert(AnotherClass.x == 10);
+assert(AnotherClass().x == 10);
+
+BaseClass.x = 100;
+
+assert(Common.x == 100);
+assert(Common().x == 100);
+assert(AnotherClass.x == 100);
+assert(AnotherClass().x == 100);
+
+
+/**
+ * Test abstract classes
+ */
+abstract class AbstractClass {
+    var x = "Hello";
+}
+
+assert(AbstractClass.x == "Hello");

--- a/tests/classes/import.du
+++ b/tests/classes/import.du
@@ -12,3 +12,4 @@ import "tests/classes/traits.du";
 import "tests/classes/copy.du";
 import "tests/classes/toString.du";
 import "tests/classes/abstract.du";
+import "tests/classes/classVariables.du";


### PR DESCRIPTION
# Class Variables
## Summary
This PR adds the ability to define properties on the class itself rather than the instance. There is probably limited use case for this, however is a welcome addition nevertheless. Class variables in Dictu mimic functionality of class variables in Python, and can be seen as a "static" variable. They differ from instance variables in that they are defined on the class (as said above) rather than the instance, therefore this means all instances share this value.

### Example
```js
class Test {
    var x = 10; // Class variable

    init() {
        this.val = 1; // Instance variable
    }
}

var x = Test();
var y = Test();

print(x.x); // 10
print(y.x); // 10

Test.x = 10000; // Update class variable

print(x.x); // 10000
print(y.x); // 10000
```