### PR TITLE
Remove "native classes" in favour of modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ time.du
 test.du
 
 coverage/
+
+compile_commands.json

--- a/c/memory.c
+++ b/c/memory.c
@@ -106,14 +106,6 @@ static void blackenObject(VM *vm, Obj *object) {
             break;
         }
 
-        case OBJ_NATIVE_CLASS: {
-            ObjClassNative *klass = (ObjClassNative *) object;
-            grayObject(vm, (Obj *) klass->name);
-            grayTable(vm, &klass->methods);
-            grayTable(vm, &klass->properties);
-            break;
-        }
-
         case OBJ_CLOSURE: {
             ObjClosure *closure = (ObjClosure *) object;
             grayObject(vm, (Obj *) closure->function);
@@ -191,14 +183,6 @@ void freeObject(VM *vm, Obj *object) {
             freeTable(vm, &klass->abstractMethods);
             freeTable(vm, &klass->properties);
             FREE(vm, ObjClass, object);
-            break;
-        }
-
-        case OBJ_NATIVE_CLASS: {
-            ObjClassNative *klass = (ObjClassNative *) object;
-            freeTable(vm, &klass->methods);
-            freeTable(vm, &klass->properties);
-            FREE(vm, ObjClassNative, object);
             break;
         }
 

--- a/c/natives.c
+++ b/c/natives.c
@@ -34,8 +34,8 @@ static Value typeNative(VM *vm, int argCount, Value *args) {
 
                 break;
             }
-            case OBJ_NATIVE_CLASS: {
-                return OBJ_VAL(copyString(vm, "class", 5));
+            case OBJ_MODULE: {
+                return OBJ_VAL(copyString(vm, "module", 6));
             }
             case OBJ_INSTANCE: {
                 ObjString *className = AS_INSTANCE(args[0])->klass->name;

--- a/c/object.c
+++ b/c/object.c
@@ -63,14 +63,6 @@ ObjClass *newClass(VM *vm, ObjString *name, ObjClass *superclass, ClassType type
     return klass;
 }
 
-ObjClassNative *newClassNative(VM *vm, ObjString *name) {
-    ObjClassNative *klass = ALLOCATE_OBJ(vm, ObjClassNative, OBJ_NATIVE_CLASS);
-    klass->name = name;
-    initTable(&klass->methods);
-    initTable(&klass->properties);
-    return klass;
-}
-
 ObjClosure *newClosure(VM *vm, ObjFunction *function) {
     ObjUpvalue **upvalues = ALLOCATE(vm, ObjUpvalue*, function->upvalueCount);
     for (int i = 0; i < function->upvalueCount; i++) {
@@ -460,7 +452,6 @@ char *objectToString(Value value) {
             return moduleString;
         }
 
-        case OBJ_NATIVE_CLASS:
         case OBJ_CLASS: {
             if (IS_TRAIT(value)) {
                 ObjClass *trait = AS_CLASS(value);

--- a/c/object.h
+++ b/c/object.h
@@ -14,7 +14,6 @@
 #define AS_MODULE(value)        ((ObjModule*)AS_OBJ(value))
 #define AS_BOUND_METHOD(value)  ((ObjBoundMethod*)AS_OBJ(value))
 #define AS_CLASS(value)         ((ObjClass*)AS_OBJ(value))
-#define AS_CLASS_NATIVE(value)  ((ObjClassNative*)AS_OBJ(value))
 #define AS_CLOSURE(value)       ((ObjClosure*)AS_OBJ(value))
 #define AS_FUNCTION(value)      ((ObjFunction*)AS_OBJ(value))
 #define AS_INSTANCE(value)      ((ObjInstance*)AS_OBJ(value))
@@ -29,7 +28,6 @@
 #define IS_MODULE(value)          isObjType(value, OBJ_MODULE)
 #define IS_BOUND_METHOD(value)    isObjType(value, OBJ_BOUND_METHOD)
 #define IS_CLASS(value)           isObjType(value, OBJ_CLASS)
-#define IS_NATIVE_CLASS(value)    isObjType(value, OBJ_NATIVE_CLASS)
 #define IS_DEFAULT_CLASS(value)   isObjType(value, OBJ_CLASS) && AS_CLASS(value)->type == CLASS_DEFAULT
 #define IS_TRAIT(value)           isObjType(value, OBJ_CLASS) && AS_CLASS(value)->type == CLASS_TRAIT
 #define IS_CLOSURE(value)         isObjType(value, OBJ_CLOSURE)
@@ -46,7 +44,6 @@ typedef enum {
     OBJ_MODULE,
     OBJ_BOUND_METHOD,
     OBJ_CLASS,
-    OBJ_NATIVE_CLASS,
     OBJ_CLOSURE,
     OBJ_FUNCTION,
     OBJ_INSTANCE,
@@ -183,13 +180,6 @@ typedef struct sObjClass {
     ClassType type;
 } ObjClass;
 
-typedef struct sObjClassNative {
-    Obj obj;
-    ObjString *name;
-    Table methods;
-    Table properties;
-} ObjClassNative;
-
 typedef struct {
     Obj obj;
     ObjClass *klass;
@@ -207,8 +197,6 @@ ObjModule *newModule(VM *vm, ObjString *name);
 ObjBoundMethod *newBoundMethod(VM *vm, Value receiver, ObjClosure *method);
 
 ObjClass *newClass(VM *vm, ObjString *name, ObjClass *superclass, ClassType type);
-
-ObjClassNative *newClassNative(VM *vm, ObjString *name);
 
 ObjClosure *newClosure(VM *vm, ObjFunction *function);
 

--- a/c/optionals/c.c
+++ b/c/optionals/c.c
@@ -48,256 +48,256 @@ Value strerrorNative(VM *vm, int argCount, Value *args) {
 void createCClass(VM *vm) {
     ObjString *name = copyString(vm, "C", 1);
     push(vm, OBJ_VAL(name));
-    ObjClassNative *klass = newClassNative(vm, name);
-    push(vm, OBJ_VAL(klass));
+    ObjModule *module = newModule(vm, name);
+    push(vm, OBJ_VAL(module));
 
     /**
      * Define C methods
      */
-    defineNative(vm, &klass->methods, "strerror", strerrorNative);
+    defineNative(vm, &module->values, "strerror", strerrorNative);
 
     /**
      * Define C properties
      */
-    defineNativeProperty(vm, &klass->properties, "EPERM",  NUMBER_VAL(EPERM));
-    defineNativeProperty(vm, &klass->properties, "ENOENT", NUMBER_VAL(ENOENT));
-    defineNativeProperty(vm, &klass->properties, "ESRCH",  NUMBER_VAL(ESRCH));
-    defineNativeProperty(vm, &klass->properties, "EINTR",  NUMBER_VAL(EINTR));
-    defineNativeProperty(vm, &klass->properties, "EIO",    NUMBER_VAL(EIO));
-    defineNativeProperty(vm, &klass->properties, "ENXIO",  NUMBER_VAL(ENXIO));
-    defineNativeProperty(vm, &klass->properties, "E2BIG",  NUMBER_VAL(E2BIG));
-    defineNativeProperty(vm, &klass->properties, "ENOEXEC",NUMBER_VAL(ENOEXEC));
-    defineNativeProperty(vm, &klass->properties, "EAGAIN", NUMBER_VAL(EAGAIN));
-    defineNativeProperty(vm, &klass->properties, "ENOMEM", NUMBER_VAL(ENOMEM));
-    defineNativeProperty(vm, &klass->properties, "EACCES", NUMBER_VAL(EACCES));
-    defineNativeProperty(vm, &klass->properties, "EFAULT", NUMBER_VAL(EFAULT));
+    defineNativeProperty(vm, &module->values, "EPERM",  NUMBER_VAL(EPERM));
+    defineNativeProperty(vm, &module->values, "ENOENT", NUMBER_VAL(ENOENT));
+    defineNativeProperty(vm, &module->values, "ESRCH",  NUMBER_VAL(ESRCH));
+    defineNativeProperty(vm, &module->values, "EINTR",  NUMBER_VAL(EINTR));
+    defineNativeProperty(vm, &module->values, "EIO",    NUMBER_VAL(EIO));
+    defineNativeProperty(vm, &module->values, "ENXIO",  NUMBER_VAL(ENXIO));
+    defineNativeProperty(vm, &module->values, "E2BIG",  NUMBER_VAL(E2BIG));
+    defineNativeProperty(vm, &module->values, "ENOEXEC",NUMBER_VAL(ENOEXEC));
+    defineNativeProperty(vm, &module->values, "EAGAIN", NUMBER_VAL(EAGAIN));
+    defineNativeProperty(vm, &module->values, "ENOMEM", NUMBER_VAL(ENOMEM));
+    defineNativeProperty(vm, &module->values, "EACCES", NUMBER_VAL(EACCES));
+    defineNativeProperty(vm, &module->values, "EFAULT", NUMBER_VAL(EFAULT));
 #ifdef ENOTBLK
-    defineNativeProperty(vm, &klass->properties, "ENOTBLK", NUMBER_VAL(ENOTBLK));
+    defineNativeProperty(vm, &module->values, "ENOTBLK", NUMBER_VAL(ENOTBLK));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EBUSY",  NUMBER_VAL(EBUSY));
-    defineNativeProperty(vm, &klass->properties, "EEXIST", NUMBER_VAL(EEXIST));
-    defineNativeProperty(vm, &klass->properties, "EXDEV",  NUMBER_VAL(EXDEV));
-    defineNativeProperty(vm, &klass->properties, "ENODEV", NUMBER_VAL(ENODEV));
-    defineNativeProperty(vm, &klass->properties, "ENOTDIR",NUMBER_VAL(ENOTDIR));
-    defineNativeProperty(vm, &klass->properties, "EISDIR", NUMBER_VAL(EISDIR));
-    defineNativeProperty(vm, &klass->properties, "EINVAL", NUMBER_VAL(EINVAL));
-    defineNativeProperty(vm, &klass->properties, "ENFILE", NUMBER_VAL(ENFILE));
-    defineNativeProperty(vm, &klass->properties, "EMFILE", NUMBER_VAL(EMFILE));
-    defineNativeProperty(vm, &klass->properties, "ENOTTY", NUMBER_VAL(ENOTTY));
-    defineNativeProperty(vm, &klass->properties, "ETXTBSY",NUMBER_VAL(ETXTBSY));
-    defineNativeProperty(vm, &klass->properties, "EFBIG",  NUMBER_VAL(EFBIG));
-    defineNativeProperty(vm, &klass->properties, "ENOSPC", NUMBER_VAL(ENOSPC));
-    defineNativeProperty(vm, &klass->properties, "ESPIPE", NUMBER_VAL(ESPIPE));
-    defineNativeProperty(vm, &klass->properties, "EROFS",  NUMBER_VAL(EROFS));
-    defineNativeProperty(vm, &klass->properties, "EMLINK", NUMBER_VAL(EMLINK));
-    defineNativeProperty(vm, &klass->properties, "EPIPE",  NUMBER_VAL(EPIPE));
-    defineNativeProperty(vm, &klass->properties, "EDOM",   NUMBER_VAL(EDOM));
-    defineNativeProperty(vm, &klass->properties, "ERANGE", NUMBER_VAL(ERANGE));
-    defineNativeProperty(vm, &klass->properties, "EDEADLK",NUMBER_VAL(EDEADLK));
-    defineNativeProperty(vm, &klass->properties, "ENAMETOOLONG", NUMBER_VAL(ENAMETOOLONG));
-    defineNativeProperty(vm, &klass->properties, "ENOLCK", NUMBER_VAL(ENOLCK));
-    defineNativeProperty(vm, &klass->properties, "ENOSYS", NUMBER_VAL(ENOSYS));
-    defineNativeProperty(vm, &klass->properties, "ENOTEMPTY", NUMBER_VAL(ENOTEMPTY));
-    defineNativeProperty(vm, &klass->properties, "ELOOP",  NUMBER_VAL(ELOOP));
-    defineNativeProperty(vm, &klass->properties, "EWOULDBLOCK", NUMBER_VAL(EWOULDBLOCK));
-    defineNativeProperty(vm, &klass->properties, "ENOMSG", NUMBER_VAL(ENOMSG));
-    defineNativeProperty(vm, &klass->properties, "EIDRM", NUMBER_VAL(EIDRM));
+    defineNativeProperty(vm, &module->values, "EBUSY",  NUMBER_VAL(EBUSY));
+    defineNativeProperty(vm, &module->values, "EEXIST", NUMBER_VAL(EEXIST));
+    defineNativeProperty(vm, &module->values, "EXDEV",  NUMBER_VAL(EXDEV));
+    defineNativeProperty(vm, &module->values, "ENODEV", NUMBER_VAL(ENODEV));
+    defineNativeProperty(vm, &module->values, "ENOTDIR",NUMBER_VAL(ENOTDIR));
+    defineNativeProperty(vm, &module->values, "EISDIR", NUMBER_VAL(EISDIR));
+    defineNativeProperty(vm, &module->values, "EINVAL", NUMBER_VAL(EINVAL));
+    defineNativeProperty(vm, &module->values, "ENFILE", NUMBER_VAL(ENFILE));
+    defineNativeProperty(vm, &module->values, "EMFILE", NUMBER_VAL(EMFILE));
+    defineNativeProperty(vm, &module->values, "ENOTTY", NUMBER_VAL(ENOTTY));
+    defineNativeProperty(vm, &module->values, "ETXTBSY",NUMBER_VAL(ETXTBSY));
+    defineNativeProperty(vm, &module->values, "EFBIG",  NUMBER_VAL(EFBIG));
+    defineNativeProperty(vm, &module->values, "ENOSPC", NUMBER_VAL(ENOSPC));
+    defineNativeProperty(vm, &module->values, "ESPIPE", NUMBER_VAL(ESPIPE));
+    defineNativeProperty(vm, &module->values, "EROFS",  NUMBER_VAL(EROFS));
+    defineNativeProperty(vm, &module->values, "EMLINK", NUMBER_VAL(EMLINK));
+    defineNativeProperty(vm, &module->values, "EPIPE",  NUMBER_VAL(EPIPE));
+    defineNativeProperty(vm, &module->values, "EDOM",   NUMBER_VAL(EDOM));
+    defineNativeProperty(vm, &module->values, "ERANGE", NUMBER_VAL(ERANGE));
+    defineNativeProperty(vm, &module->values, "EDEADLK",NUMBER_VAL(EDEADLK));
+    defineNativeProperty(vm, &module->values, "ENAMETOOLONG", NUMBER_VAL(ENAMETOOLONG));
+    defineNativeProperty(vm, &module->values, "ENOLCK", NUMBER_VAL(ENOLCK));
+    defineNativeProperty(vm, &module->values, "ENOSYS", NUMBER_VAL(ENOSYS));
+    defineNativeProperty(vm, &module->values, "ENOTEMPTY", NUMBER_VAL(ENOTEMPTY));
+    defineNativeProperty(vm, &module->values, "ELOOP",  NUMBER_VAL(ELOOP));
+    defineNativeProperty(vm, &module->values, "EWOULDBLOCK", NUMBER_VAL(EWOULDBLOCK));
+    defineNativeProperty(vm, &module->values, "ENOMSG", NUMBER_VAL(ENOMSG));
+    defineNativeProperty(vm, &module->values, "EIDRM", NUMBER_VAL(EIDRM));
 #ifdef ECHRNG
-    defineNativeProperty(vm, &klass->properties, "ECHRNG", NUMBER_VAL(ECHRNG));
+    defineNativeProperty(vm, &module->values, "ECHRNG", NUMBER_VAL(ECHRNG));
 #endif
 #ifdef EL2NSYNC
-    defineNativeProperty(vm, &klass->properties, "EL2NSYNC", NUMBER_VAL(EL2NSYNC));
+    defineNativeProperty(vm, &module->values, "EL2NSYNC", NUMBER_VAL(EL2NSYNC));
 #endif
 #ifdef EL3HLT
-    defineNativeProperty(vm, &klass->properties, "EL3HLT", NUMBER_VAL(EL3HLT));
+    defineNativeProperty(vm, &module->values, "EL3HLT", NUMBER_VAL(EL3HLT));
 #endif
 #ifdef EL3RST
-    defineNativeProperty(vm, &klass->properties, "EL3RST", NUMBER_VAL(EL3RST));
+    defineNativeProperty(vm, &module->values, "EL3RST", NUMBER_VAL(EL3RST));
 #endif
 #ifdef ELNRNG
-    defineNativeProperty(vm, &klass->properties, "ELNRNG", NUMBER_VAL(ELNRNG));
+    defineNativeProperty(vm, &module->values, "ELNRNG", NUMBER_VAL(ELNRNG));
 #endif
 #ifdef EUNATCH
-    defineNativeProperty(vm, &klass->properties, "EUNATCH", NUMBER_VAL(EUNATCH));
+    defineNativeProperty(vm, &module->values, "EUNATCH", NUMBER_VAL(EUNATCH));
 #endif
 #ifdef ENOCSI
-    defineNativeProperty(vm, &klass->properties, "ENOCSI", NUMBER_VAL(ENOCSI));
+    defineNativeProperty(vm, &module->values, "ENOCSI", NUMBER_VAL(ENOCSI));
 #endif
 #ifdef EL2HLT
-    defineNativeProperty(vm, &klass->properties, "EL2HLT", NUMBER_VAL(EL2HLT));
+    defineNativeProperty(vm, &module->values, "EL2HLT", NUMBER_VAL(EL2HLT));
 #endif
 #ifdef EBADE
-    defineNativeProperty(vm, &klass->properties, "EBADE", NUMBER_VAL(EBADE));
+    defineNativeProperty(vm, &module->values, "EBADE", NUMBER_VAL(EBADE));
 #endif
 #ifdef EBADR
-    defineNativeProperty(vm, &klass->properties, "EBADR", NUMBER_VAL(EBADR));
+    defineNativeProperty(vm, &module->values, "EBADR", NUMBER_VAL(EBADR));
 #endif
 #ifdef EXFULL
-    defineNativeProperty(vm, &klass->properties, "EXFULL", NUMBER_VAL(EXFULL));
+    defineNativeProperty(vm, &module->values, "EXFULL", NUMBER_VAL(EXFULL));
 #endif
 #ifdef ENOANO
-    defineNativeProperty(vm, &klass->properties, "ENOANO", NUMBER_VAL(ENOANO));
+    defineNativeProperty(vm, &module->values, "ENOANO", NUMBER_VAL(ENOANO));
 #endif
 #ifdef EBADRQC
-    defineNativeProperty(vm, &klass->properties, "EBADRQC", NUMBER_VAL(EBADRQC));
+    defineNativeProperty(vm, &module->values, "EBADRQC", NUMBER_VAL(EBADRQC));
 #endif
 #ifdef EBADSLT
-    defineNativeProperty(vm, &klass->properties, "EBADSLT", NUMBER_VAL(EBADSLT));
+    defineNativeProperty(vm, &module->values, "EBADSLT", NUMBER_VAL(EBADSLT));
 #endif
 #ifdef EDEADLOCK
-    defineNativeProperty(vm, &klass->properties, "EDEADLOCK", NUMBER_VAL(EDEADLOCK));
+    defineNativeProperty(vm, &module->values, "EDEADLOCK", NUMBER_VAL(EDEADLOCK));
 #endif
 #ifdef EBFONT
-    defineNativeProperty(vm, &klass->properties, "EBFONT", NUMBER_VAL(EBFONT));
+    defineNativeProperty(vm, &module->values, "EBFONT", NUMBER_VAL(EBFONT));
 #endif
-    defineNativeProperty(vm, &klass->properties, "ENOSTR", NUMBER_VAL(ENOSTR));
-    defineNativeProperty(vm, &klass->properties, "ENODATA", NUMBER_VAL(ENODATA));
-    defineNativeProperty(vm, &klass->properties, "ETIME", NUMBER_VAL(ETIME));
-    defineNativeProperty(vm, &klass->properties, "ENOSR", NUMBER_VAL(ENOSR));
+    defineNativeProperty(vm, &module->values, "ENOSTR", NUMBER_VAL(ENOSTR));
+    defineNativeProperty(vm, &module->values, "ENODATA", NUMBER_VAL(ENODATA));
+    defineNativeProperty(vm, &module->values, "ETIME", NUMBER_VAL(ETIME));
+    defineNativeProperty(vm, &module->values, "ENOSR", NUMBER_VAL(ENOSR));
 #ifdef ENONET
-    defineNativeProperty(vm, &klass->properties, "ENONET", NUMBER_VAL(ENONET));
+    defineNativeProperty(vm, &module->values, "ENONET", NUMBER_VAL(ENONET));
 #endif
 #ifdef ENOPKG
-    defineNativeProperty(vm, &klass->properties, "ENOPKG", NUMBER_VAL(ENOPKG));
+    defineNativeProperty(vm, &module->values, "ENOPKG", NUMBER_VAL(ENOPKG));
 #endif
 #ifdef EREMOTE
-    defineNativeProperty(vm, &klass->properties, "EREMOTE", NUMBER_VAL(EREMOTE));
+    defineNativeProperty(vm, &module->values, "EREMOTE", NUMBER_VAL(EREMOTE));
 #endif
-    defineNativeProperty(vm, &klass->properties, "ENOLINK", NUMBER_VAL(ENOLINK));
+    defineNativeProperty(vm, &module->values, "ENOLINK", NUMBER_VAL(ENOLINK));
 #ifdef EADV
-    defineNativeProperty(vm, &klass->properties, "EADV", NUMBER_VAL(EADV));
+    defineNativeProperty(vm, &module->values, "EADV", NUMBER_VAL(EADV));
 #endif
 #ifdef ESRMNT
-    defineNativeProperty(vm, &klass->properties, "ESRMNT", NUMBER_VAL(ESRMNT));
+    defineNativeProperty(vm, &module->values, "ESRMNT", NUMBER_VAL(ESRMNT));
 #endif
 #ifdef ECOMM
-    defineNativeProperty(vm, &klass->properties, "ECOMM", NUMBER_VAL(ECOMM));
+    defineNativeProperty(vm, &module->values, "ECOMM", NUMBER_VAL(ECOMM));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EPROTO", NUMBER_VAL(EPROTO));
-    defineNativeProperty(vm, &klass->properties, "EMULTIHOP", NUMBER_VAL(EMULTIHOP));
+    defineNativeProperty(vm, &module->values, "EPROTO", NUMBER_VAL(EPROTO));
+    defineNativeProperty(vm, &module->values, "EMULTIHOP", NUMBER_VAL(EMULTIHOP));
 #ifdef EDOTDOT
-    defineNativeProperty(vm, &klass->properties, "EDOTDOT", NUMBER_VAL(EDOTDOT));
+    defineNativeProperty(vm, &module->values, "EDOTDOT", NUMBER_VAL(EDOTDOT));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EBADMSG", NUMBER_VAL(EBADMSG));
-    defineNativeProperty(vm, &klass->properties, "EOVERFLOW", NUMBER_VAL(EOVERFLOW));
+    defineNativeProperty(vm, &module->values, "EBADMSG", NUMBER_VAL(EBADMSG));
+    defineNativeProperty(vm, &module->values, "EOVERFLOW", NUMBER_VAL(EOVERFLOW));
 #ifdef ENOTUNIQ
-    defineNativeProperty(vm, &klass->properties, "ENOTUNIQ", NUMBER_VAL(ENOTUNIQ));
+    defineNativeProperty(vm, &module->values, "ENOTUNIQ", NUMBER_VAL(ENOTUNIQ));
 #endif
 #ifdef EBADFD
-    defineNativeProperty(vm, &klass->properties, "EBADFD", NUMBER_VAL(EBADFD));
+    defineNativeProperty(vm, &module->values, "EBADFD", NUMBER_VAL(EBADFD));
 #endif
 #ifdef EREMCHG
-    defineNativeProperty(vm, &klass->properties, "EREMCHG", NUMBER_VAL(EREMCHG));
+    defineNativeProperty(vm, &module->values, "EREMCHG", NUMBER_VAL(EREMCHG));
 #endif
 #ifdef ELIBACC
-    defineNativeProperty(vm, &klass->properties, "ELIBACC", NUMBER_VAL(ELIBACC));
+    defineNativeProperty(vm, &module->values, "ELIBACC", NUMBER_VAL(ELIBACC));
 #endif
 #ifdef ELIBBAD
-    defineNativeProperty(vm, &klass->properties, "ELIBBAD", NUMBER_VAL(ELIBBAD));
+    defineNativeProperty(vm, &module->values, "ELIBBAD", NUMBER_VAL(ELIBBAD));
 #endif
 #ifdef ELIBSCN
-    defineNativeProperty(vm, &klass->properties, "ELIBSCN", NUMBER_VAL(ELIBSCN));
+    defineNativeProperty(vm, &module->values, "ELIBSCN", NUMBER_VAL(ELIBSCN));
 #endif
 #ifdef ELIBMAX
-    defineNativeProperty(vm, &klass->properties, "ELIBMAX", NUMBER_VAL(ELIBMAX));
+    defineNativeProperty(vm, &module->values, "ELIBMAX", NUMBER_VAL(ELIBMAX));
 #endif
 #ifdef ELIBEXEC
-    defineNativeProperty(vm, &klass->properties, "ELIBEXEC", NUMBER_VAL(ELIBEXEC));
+    defineNativeProperty(vm, &module->values, "ELIBEXEC", NUMBER_VAL(ELIBEXEC));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EILSEQ", NUMBER_VAL(EILSEQ));
+    defineNativeProperty(vm, &module->values, "EILSEQ", NUMBER_VAL(EILSEQ));
 #ifdef ERESTART
-    defineNativeProperty(vm, &klass->properties, "ERESTART", NUMBER_VAL(ERESTART));
+    defineNativeProperty(vm, &module->values, "ERESTART", NUMBER_VAL(ERESTART));
 #endif
 #ifdef ESTRPIPE
-    defineNativeProperty(vm, &klass->properties, "ESTRPIPE", NUMBER_VAL(ESTRPIPE));
+    defineNativeProperty(vm, &module->values, "ESTRPIPE", NUMBER_VAL(ESTRPIPE));
 #endif
 #ifdef EUSERS
-    defineNativeProperty(vm, &klass->properties, "EUSERS", NUMBER_VAL(EUSERS));
+    defineNativeProperty(vm, &module->values, "EUSERS", NUMBER_VAL(EUSERS));
 #endif
-    defineNativeProperty(vm, &klass->properties, "ENOTSOCK", NUMBER_VAL(ENOTSOCK));
-    defineNativeProperty(vm, &klass->properties, "EDESTADDRREQ", NUMBER_VAL(EDESTADDRREQ));
-    defineNativeProperty(vm, &klass->properties, "EMSGSIZE", NUMBER_VAL(EMSGSIZE));
-    defineNativeProperty(vm, &klass->properties, "EPROTOTYPE", NUMBER_VAL(EPROTOTYPE));
-    defineNativeProperty(vm, &klass->properties, "ENOPROTOOPT", NUMBER_VAL(ENOPROTOOPT));
-    defineNativeProperty(vm, &klass->properties, "EPROTONOSUPPORT", NUMBER_VAL(EPROTONOSUPPORT));
+    defineNativeProperty(vm, &module->values, "ENOTSOCK", NUMBER_VAL(ENOTSOCK));
+    defineNativeProperty(vm, &module->values, "EDESTADDRREQ", NUMBER_VAL(EDESTADDRREQ));
+    defineNativeProperty(vm, &module->values, "EMSGSIZE", NUMBER_VAL(EMSGSIZE));
+    defineNativeProperty(vm, &module->values, "EPROTOTYPE", NUMBER_VAL(EPROTOTYPE));
+    defineNativeProperty(vm, &module->values, "ENOPROTOOPT", NUMBER_VAL(ENOPROTOOPT));
+    defineNativeProperty(vm, &module->values, "EPROTONOSUPPORT", NUMBER_VAL(EPROTONOSUPPORT));
 #ifdef ESOCKTNOSUPPORT
-    defineNativeProperty(vm, &klass->properties, "ESOCKTNOSUPPORT", NUMBER_VAL(ESOCKTNOSUPPORT));
+    defineNativeProperty(vm, &module->values, "ESOCKTNOSUPPORT", NUMBER_VAL(ESOCKTNOSUPPORT));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EOPNOTSUPP", NUMBER_VAL(EOPNOTSUPP));
+    defineNativeProperty(vm, &module->values, "EOPNOTSUPP", NUMBER_VAL(EOPNOTSUPP));
 #ifdef EPFNOSUPPORT
-    defineNativeProperty(vm, &klass->properties, "EPFNOSUPPORT", NUMBER_VAL(EPFNOSUPPORT));
+    defineNativeProperty(vm, &module->values, "EPFNOSUPPORT", NUMBER_VAL(EPFNOSUPPORT));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EAFNOSUPPORT", NUMBER_VAL(EAFNOSUPPORT));
-    defineNativeProperty(vm, &klass->properties, "EADDRINUSE", NUMBER_VAL(EADDRINUSE));
-    defineNativeProperty(vm, &klass->properties, "EADDRNOTAVAIL", NUMBER_VAL(EADDRNOTAVAIL));
-    defineNativeProperty(vm, &klass->properties, "ENETDOWN", NUMBER_VAL(ENETDOWN));
-    defineNativeProperty(vm, &klass->properties, "ENETUNREACH", NUMBER_VAL(ENETUNREACH));
-    defineNativeProperty(vm, &klass->properties, "ENETRESET", NUMBER_VAL(ENETRESET));
-    defineNativeProperty(vm, &klass->properties, "ECONNABORTED", NUMBER_VAL(ECONNABORTED));
-    defineNativeProperty(vm, &klass->properties, "ECONNRESET", NUMBER_VAL(ECONNRESET));
-    defineNativeProperty(vm, &klass->properties, "ENOBUFS", NUMBER_VAL(ENOBUFS));
-    defineNativeProperty(vm, &klass->properties, "EISCONN", NUMBER_VAL(EISCONN));
-    defineNativeProperty(vm, &klass->properties, "ENOTCONN", NUMBER_VAL(ENOTCONN));
+    defineNativeProperty(vm, &module->values, "EAFNOSUPPORT", NUMBER_VAL(EAFNOSUPPORT));
+    defineNativeProperty(vm, &module->values, "EADDRINUSE", NUMBER_VAL(EADDRINUSE));
+    defineNativeProperty(vm, &module->values, "EADDRNOTAVAIL", NUMBER_VAL(EADDRNOTAVAIL));
+    defineNativeProperty(vm, &module->values, "ENETDOWN", NUMBER_VAL(ENETDOWN));
+    defineNativeProperty(vm, &module->values, "ENETUNREACH", NUMBER_VAL(ENETUNREACH));
+    defineNativeProperty(vm, &module->values, "ENETRESET", NUMBER_VAL(ENETRESET));
+    defineNativeProperty(vm, &module->values, "ECONNABORTED", NUMBER_VAL(ECONNABORTED));
+    defineNativeProperty(vm, &module->values, "ECONNRESET", NUMBER_VAL(ECONNRESET));
+    defineNativeProperty(vm, &module->values, "ENOBUFS", NUMBER_VAL(ENOBUFS));
+    defineNativeProperty(vm, &module->values, "EISCONN", NUMBER_VAL(EISCONN));
+    defineNativeProperty(vm, &module->values, "ENOTCONN", NUMBER_VAL(ENOTCONN));
 #ifdef ESHUTDOWN
-    defineNativeProperty(vm, &klass->properties, "ESHUTDOWN", NUMBER_VAL(ESHUTDOWN));
+    defineNativeProperty(vm, &module->values, "ESHUTDOWN", NUMBER_VAL(ESHUTDOWN));
 #endif
 #ifdef ETOOMANYREFS
-    defineNativeProperty(vm, &klass->properties, "ETOOMANYREFS", NUMBER_VAL(ETOOMANYREFS));
+    defineNativeProperty(vm, &module->values, "ETOOMANYREFS", NUMBER_VAL(ETOOMANYREFS));
 #endif
-    defineNativeProperty(vm, &klass->properties, "ETIMEDOUT", NUMBER_VAL(ETIMEDOUT));
-    defineNativeProperty(vm, &klass->properties, "ECONNREFUSED", NUMBER_VAL(ECONNREFUSED));
+    defineNativeProperty(vm, &module->values, "ETIMEDOUT", NUMBER_VAL(ETIMEDOUT));
+    defineNativeProperty(vm, &module->values, "ECONNREFUSED", NUMBER_VAL(ECONNREFUSED));
 #ifdef EHOSTDOWN
-    defineNativeProperty(vm, &klass->properties, "EHOSTDOWN", NUMBER_VAL(EHOSTDOWN));
+    defineNativeProperty(vm, &module->values, "EHOSTDOWN", NUMBER_VAL(EHOSTDOWN));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EHOSTUNREACH", NUMBER_VAL(EHOSTUNREACH));
-    defineNativeProperty(vm, &klass->properties, "EALREADY", NUMBER_VAL(EALREADY));
-    defineNativeProperty(vm, &klass->properties, "EINPROGRESS", NUMBER_VAL(EINPROGRESS));
-    defineNativeProperty(vm, &klass->properties, "ESTALE", NUMBER_VAL(ESTALE));
+    defineNativeProperty(vm, &module->values, "EHOSTUNREACH", NUMBER_VAL(EHOSTUNREACH));
+    defineNativeProperty(vm, &module->values, "EALREADY", NUMBER_VAL(EALREADY));
+    defineNativeProperty(vm, &module->values, "EINPROGRESS", NUMBER_VAL(EINPROGRESS));
+    defineNativeProperty(vm, &module->values, "ESTALE", NUMBER_VAL(ESTALE));
 #ifdef EUCLEAN
-    defineNativeProperty(vm, &klass->properties, "EUCLEAN", NUMBER_VAL(EUCLEAN));
+    defineNativeProperty(vm, &module->values, "EUCLEAN", NUMBER_VAL(EUCLEAN));
 #endif
 #ifdef ENOTNAM
-    defineNativeProperty(vm, &klass->properties, "ENOTNAM", NUMBER_VAL(ENOTNAM));
+    defineNativeProperty(vm, &module->values, "ENOTNAM", NUMBER_VAL(ENOTNAM));
 #endif
 #ifdef ENAVAIL
-    defineNativeProperty(vm, &klass->properties, "ENAVAIL", NUMBER_VAL(ENAVAIL));
+    defineNativeProperty(vm, &module->values, "ENAVAIL", NUMBER_VAL(ENAVAIL));
 #endif
 #ifdef EISNAM
-    defineNativeProperty(vm, &klass->properties, "EISNAM", NUMBER_VAL(EISNAM));
+    defineNativeProperty(vm, &module->values, "EISNAM", NUMBER_VAL(EISNAM));
 #endif
 #ifdef EREMOTEIO
-    defineNativeProperty(vm, &klass->properties, "EREMOTEIO", NUMBER_VAL(EREMOTEIO));
+    defineNativeProperty(vm, &module->values, "EREMOTEIO", NUMBER_VAL(EREMOTEIO));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EDQUOT", NUMBER_VAL(EDQUOT));
+    defineNativeProperty(vm, &module->values, "EDQUOT", NUMBER_VAL(EDQUOT));
 #ifdef ENOMEDIUM
-    defineNativeProperty(vm, &klass->properties, "ENOMEDIUM", NUMBER_VAL(ENOMEDIUM));
+    defineNativeProperty(vm, &module->values, "ENOMEDIUM", NUMBER_VAL(ENOMEDIUM));
 #endif
 #ifdef EMEDIUMTYPE
-    defineNativeProperty(vm, &klass->properties, "EMEDIUMTYPE", NUMBER_VAL(EMEDIUMTYPE));
+    defineNativeProperty(vm, &module->values, "EMEDIUMTYPE", NUMBER_VAL(EMEDIUMTYPE));
 #endif
-    defineNativeProperty(vm, &klass->properties, "ECANCELED", NUMBER_VAL(ECANCELED));
+    defineNativeProperty(vm, &module->values, "ECANCELED", NUMBER_VAL(ECANCELED));
 #ifdef ENOKEY
-    defineNativeProperty(vm, &klass->properties, "ENOKEY", NUMBER_VAL(ENOKEY));
+    defineNativeProperty(vm, &module->values, "ENOKEY", NUMBER_VAL(ENOKEY));
 #endif
 #ifdef EKEYEXPIRED
-    defineNativeProperty(vm, &klass->properties, "EKEYEXPIRED", NUMBER_VAL(EKEYEXPIRED));
+    defineNativeProperty(vm, &module->values, "EKEYEXPIRED", NUMBER_VAL(EKEYEXPIRED));
 #endif
 #ifdef EKEYREVOKED
-    defineNativeProperty(vm, &klass->properties, "EKEYREVOKED", NUMBER_VAL(EKEYREVOKED));
+    defineNativeProperty(vm, &module->values, "EKEYREVOKED", NUMBER_VAL(EKEYREVOKED));
 #endif
 #ifdef EKEYREJECTED
-    defineNativeProperty(vm, &klass->properties, "EKEYREJECTED", NUMBER_VAL(EKEYREJECTED));
+    defineNativeProperty(vm, &module->values, "EKEYREJECTED", NUMBER_VAL(EKEYREJECTED));
 #endif
-    defineNativeProperty(vm, &klass->properties, "EOWNERDEAD", NUMBER_VAL(EOWNERDEAD));
-    defineNativeProperty(vm, &klass->properties, "ENOTRECOVERABLE", NUMBER_VAL(ENOTRECOVERABLE));
+    defineNativeProperty(vm, &module->values, "EOWNERDEAD", NUMBER_VAL(EOWNERDEAD));
+    defineNativeProperty(vm, &module->values, "ENOTRECOVERABLE", NUMBER_VAL(ENOTRECOVERABLE));
 #ifdef ERFKILL
-    defineNativeProperty(vm, &klass->properties, "ERFKILL", NUMBER_VAL(ERFKILL));
+    defineNativeProperty(vm, &module->values, "ERFKILL", NUMBER_VAL(ERFKILL));
 #endif
 #ifdef EHWPOISON
-    defineNativeProperty(vm, &klass->properties, "EHWPOISON", NUMBER_VAL(EHWPOISON));
+    defineNativeProperty(vm, &module->values, "EHWPOISON", NUMBER_VAL(EHWPOISON));
 #endif
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
+    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 }

--- a/c/optionals/datetime.c
+++ b/c/optionals/datetime.c
@@ -142,18 +142,18 @@ static Value strptimeNative(VM *vm, int argCount, Value *args) {
 void createDatetimeClass(VM *vm) {
     ObjString *name = copyString(vm, "Datetime", 8);
     push(vm, OBJ_VAL(name));
-    ObjClassNative *klass = newClassNative(vm, name);
-    push(vm, OBJ_VAL(klass));
+    ObjModule *module = newModule(vm, name);
+    push(vm, OBJ_VAL(module));
 
     /**
      * Define Datetime methods
      */
-    defineNative(vm, &klass->methods, "now", nowNative);
-    defineNative(vm, &klass->methods, "nowUTC", nowUTCNative);
-    defineNative(vm, &klass->methods, "strftime", strftimeNative);
-    defineNative(vm, &klass->methods, "strptime", strptimeNative);
+    defineNative(vm, &module->values, "now", nowNative);
+    defineNative(vm, &module->values, "nowUTC", nowUTCNative);
+    defineNative(vm, &module->values, "strftime", strftimeNative);
+    defineNative(vm, &module->values, "strptime", strptimeNative);
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
+    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 }

--- a/c/optionals/env.c
+++ b/c/optionals/env.c
@@ -56,17 +56,17 @@ static Value set(VM *vm, int argCount, Value *args) {
 void createEnvClass(VM *vm) {
     ObjString *name = copyString(vm, "Env", 3);
     push(vm, OBJ_VAL(name));
-    ObjClassNative *klass = newClassNative(vm, name);
-    push(vm, OBJ_VAL(klass));
+    ObjModule *module = newModule(vm, name);
+    push(vm, OBJ_VAL(module));
 
     /**
      * Define Env methods
      */
-    defineNative(vm, &klass->methods, "strerror", strerrorNative);
-    defineNative(vm, &klass->methods, "get", get);
-    defineNative(vm, &klass->methods, "set", set);
+    defineNative(vm, &module->values, "strerror", strerrorNative);
+    defineNative(vm, &module->values, "get", get);
+    defineNative(vm, &module->values, "set", set);
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
+    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 }

--- a/c/optionals/http.c
+++ b/c/optionals/http.c
@@ -298,22 +298,22 @@ static Value post(VM *vm, int argCount, Value *args) {
 void createHTTPClass(VM *vm) {
     ObjString *name = copyString(vm, "HTTP", 4);
     push(vm, OBJ_VAL(name));
-    ObjClassNative *klass = newClassNative(vm, name);
-    push(vm, OBJ_VAL(klass));
+    ObjModule *module = newModule(vm, name);
+    push(vm, OBJ_VAL(module));
 
     /**
      * Define Http methods
      */
-    defineNative(vm, &klass->methods, "strerror", strerrorHttpNative);
-    defineNative(vm, &klass->methods, "get", get);
-    defineNative(vm, &klass->methods, "post", post);
+    defineNative(vm, &module->values, "strerror", strerrorHttpNative);
+    defineNative(vm, &module->values, "get", get);
+    defineNative(vm, &module->values, "post", post);
 
     /**
      * Define Http properties
      */
-    defineNativeProperty(vm, &klass->properties, "errno", NUMBER_VAL(0));
+    defineNativeProperty(vm, &module->values, "errno", NUMBER_VAL(0));
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
+    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 }

--- a/c/optionals/json.c
+++ b/c/optionals/json.c
@@ -266,26 +266,26 @@ static Value stringify(VM *vm, int argCount, Value *args) {
 void createJSONClass(VM *vm) {
     ObjString *name = copyString(vm, "JSON", 4);
     push(vm, OBJ_VAL(name));
-    ObjClassNative *klass = newClassNative(vm, name);
-    push(vm, OBJ_VAL(klass));
+    ObjModule *module = newModule(vm, name);
+    push(vm, OBJ_VAL(module));
 
     /**
      * Define Json methods
      */
-    defineNative(vm, &klass->methods, "strerror", strerrorJsonNative);
-    defineNative(vm, &klass->methods, "parse", parse);
-    defineNative(vm, &klass->methods, "stringify", stringify);
+    defineNative(vm, &module->values, "strerror", strerrorJsonNative);
+    defineNative(vm, &module->values, "parse", parse);
+    defineNative(vm, &module->values, "stringify", stringify);
 
     /**
      * Define Json properties
      */
-    defineNativeProperty(vm, &klass->properties, "errno", NUMBER_VAL(0));
-    defineNativeProperty(vm, &klass->properties, "ENULL", NUMBER_VAL(JSON_ENULL));
-    defineNativeProperty(vm, &klass->properties, "ENOTYPE", NUMBER_VAL(JSON_ENOTYPE));
-    defineNativeProperty(vm, &klass->properties, "EINVAL", NUMBER_VAL(JSON_EINVAL));
-    defineNativeProperty(vm, &klass->properties, "ENOSERIAL", NUMBER_VAL(JSON_ENOSERIAL));
+    defineNativeProperty(vm, &module->values, "errno", NUMBER_VAL(0));
+    defineNativeProperty(vm, &module->values, "ENULL", NUMBER_VAL(JSON_ENULL));
+    defineNativeProperty(vm, &module->values, "ENOTYPE", NUMBER_VAL(JSON_ENOTYPE));
+    defineNativeProperty(vm, &module->values, "EINVAL", NUMBER_VAL(JSON_EINVAL));
+    defineNativeProperty(vm, &module->values, "ENOSERIAL", NUMBER_VAL(JSON_ENOSERIAL));
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
+    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 }

--- a/c/optionals/math.c
+++ b/c/optionals/math.c
@@ -86,9 +86,7 @@ static Value absNative(VM *vm, int argCount, Value *args) {
     return NUMBER_VAL(absValue);
 }
 
-static Value sumNative(VM *vm, int argCount, Value *args) {
-    double sum = 0;
-
+static Value maxNative(VM *vm, int argCount, Value *args) {
     if (argCount == 0) {
         return NUMBER_VAL(0);
     } else if (argCount == 1 && IS_LIST(args[0])) {
@@ -97,16 +95,23 @@ static Value sumNative(VM *vm, int argCount, Value *args) {
         args = list->values.values;
     }
 
-    for (int i = 0; i < argCount; ++i) {
+    double maximum = AS_NUMBER(args[0]);
+
+    for (int i = 1; i < argCount; ++i) {
         Value value = args[i];
         if (!IS_NUMBER(value)) {
-            runtimeError(vm, "A non-number value passed to sum()");
+            runtimeError(vm, "A non-number value passed to max()");
             return EMPTY_VAL;
         }
-        sum = sum + AS_NUMBER(value);
+
+        double current = AS_NUMBER(value);
+
+        if (maximum < current) {
+            maximum = current;
+        }
     }
 
-    return NUMBER_VAL(sum);
+    return NUMBER_VAL(maximum);
 }
 
 static Value minNative(VM *vm, int argCount, Value *args) {
@@ -137,7 +142,9 @@ static Value minNative(VM *vm, int argCount, Value *args) {
     return NUMBER_VAL(minimum);
 }
 
-static Value maxNative(VM *vm, int argCount, Value *args) {
+static Value sumNative(VM *vm, int argCount, Value *args) {
+    double sum = 0;
+
     if (argCount == 0) {
         return NUMBER_VAL(0);
     } else if (argCount == 1 && IS_LIST(args[0])) {
@@ -146,50 +153,51 @@ static Value maxNative(VM *vm, int argCount, Value *args) {
         args = list->values.values;
     }
 
-    double maximum = AS_NUMBER(args[0]);
-
-    for (int i = 1; i < argCount; ++i) {
+    for (int i = 0; i < argCount; ++i) {
         Value value = args[i];
         if (!IS_NUMBER(value)) {
-            runtimeError(vm, "A non-number value passed to max()");
+            runtimeError(vm, "A non-number value passed to sum()");
             return EMPTY_VAL;
         }
-
-        double current = AS_NUMBER(value);
-
-        if (maximum < current) {
-            maximum = current;
-        }
+        sum = sum + AS_NUMBER(value);
     }
 
-    return NUMBER_VAL(maximum);
+    return NUMBER_VAL(sum);
+}
+
+static Value sqrtNative(VM *vm, int argCount, Value *args) {
+    UNUSED(vm);
+    UNUSED(argCount);
+
+    return NUMBER_VAL(sqrt(AS_NUMBER(args[0])));
 }
 
 void createMathsClass(VM *vm) {
     ObjString *name = copyString(vm, "Math", 4);
     push(vm, OBJ_VAL(name));
-    ObjClassNative *klass = newClassNative(vm, name);
-    push(vm, OBJ_VAL(klass));
+    ObjModule *module = newModule(vm, name);
+    push(vm, OBJ_VAL(module));
 
     /**
-     * Define Math methods
+     * Define Math values
      */
-    defineNative(vm, &klass->methods, "average", averageNative);
-    defineNative(vm, &klass->methods, "floor", floorNative);
-    defineNative(vm, &klass->methods, "round", roundNative);
-    defineNative(vm, &klass->methods, "ceil", ceilNative);
-    defineNative(vm, &klass->methods, "abs", absNative);
-    defineNative(vm, &klass->methods, "max", maxNative);
-    defineNative(vm, &klass->methods, "min", minNative);
-    defineNative(vm, &klass->methods, "sum", sumNative);
+    defineNative(vm, &module->values, "average", averageNative);
+    defineNative(vm, &module->values, "floor", floorNative);
+    defineNative(vm, &module->values, "round", roundNative);
+    defineNative(vm, &module->values, "ceil", ceilNative);
+    defineNative(vm, &module->values, "abs", absNative);
+    defineNative(vm, &module->values, "max", maxNative);
+    defineNative(vm, &module->values, "min", minNative);
+    defineNative(vm, &module->values, "sum", sumNative);
+    defineNative(vm, &module->values, "sqrt", sqrtNative);
 
     /**
      * Define Math properties
      */
-    defineNativeProperty(vm, &klass->properties, "PI", NUMBER_VAL(3.14159265358979));
-    defineNativeProperty(vm, &klass->properties, "e", NUMBER_VAL(2.71828182845905));
+    defineNativeProperty(vm, &module->values, "PI", NUMBER_VAL(3.14159265358979));
+    defineNativeProperty(vm, &module->values, "e", NUMBER_VAL(2.71828182845905));
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
+    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 }

--- a/c/optionals/optionals.h
+++ b/c/optionals/optionals.h
@@ -12,15 +12,15 @@
 #include "datetime.h"
 
 #define GET_SELF_CLASS \
-  AS_CLASS_NATIVE(args[-1])
+  AS_MODULE(args[-1])
 
-#define SET_ERRNO(klass_)                                              \
-  defineNativeProperty(vm, &klass_->properties, "errno", NUMBER_VAL(errno))
+#define SET_ERRNO(module_)                                              \
+  defineNativeProperty(vm, &module_->values, "errno", NUMBER_VAL(errno))
 
-#define GET_ERRNO(klass_)({                          \
+#define GET_ERRNO(module_)({                         \
   Value errno_value = 0;                             \
   ObjString *name = copyString(vm, "errno", 5);      \
-  tableGet(&klass_->properties, name, &errno_value); \
+  tableGet(&module_->values, name, &errno_value);    \
   errno_value;                                       \
 })
 

--- a/c/optionals/path.c
+++ b/c/optionals/path.c
@@ -153,28 +153,28 @@ static Value dirnameNative(VM *vm, int argCount, Value *args) {
 void createPathClass(VM *vm) {
     ObjString *name = copyString(vm, "Path", 4);
     push(vm, OBJ_VAL(name));
-    ObjClassNative *klass = newClassNative(vm, name);
-    push(vm, OBJ_VAL(klass));
+    ObjModule *module = newModule(vm, name);
+    push(vm, OBJ_VAL(module));
 
     /**
      * Define Path methods
      */
 #ifdef HAS_REALPATH
-    defineNative(vm, &klass->methods, "realpath", realpathNative);
-    defineNativeProperty(vm, &klass->properties, "errno", NUMBER_VAL(0));
-    defineNative(vm, &klass->methods, "strerror", strerrorNative); // only realpath uset errno
+    defineNative(vm, &module->values, "realpath", realpathNative);
+    defineNativeProperty(vm, &module->values, "errno", NUMBER_VAL(0));
+    defineNative(vm, &module->values, "strerror", strerrorNative); // only realpath uset errno
 #endif
-    defineNative(vm, &klass->methods, "isAbsolute", isAbsoluteNative);
-    defineNative(vm, &klass->methods, "basename", basenameNative);
-    defineNative(vm, &klass->methods, "extname", extnameNative);
-    defineNative(vm, &klass->methods, "dirname", dirnameNative);
+    defineNative(vm, &module->values, "isAbsolute", isAbsoluteNative);
+    defineNative(vm, &module->values, "basename", basenameNative);
+    defineNative(vm, &module->values, "extname", extnameNative);
+    defineNative(vm, &module->values, "dirname", dirnameNative);
 
-    defineNativeProperty(vm, &klass->properties, "delimiter", OBJ_VAL(
+    defineNativeProperty(vm, &module->values, "delimiter", OBJ_VAL(
         copyString(vm, PATH_DELIMITER_AS_STRING, PATH_DELIMITER_STRLEN)));
-    defineNativeProperty(vm, &klass->properties, "dirSeparator", OBJ_VAL(
+    defineNativeProperty(vm, &module->values, "dirSeparator", OBJ_VAL(
         copyString(vm, DIR_SEPARATOR_AS_STRING, DIR_SEPARATOR_STRLEN)));
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
+    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 }

--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -270,58 +270,58 @@ void initPlatform(VM *vm, Table *table) {
 void createSystemClass(VM *vm, int argc, const char *argv[]) {
     ObjString *name = copyString(vm, "System", 6);
     push(vm, OBJ_VAL(name));
-    ObjClassNative *klass = newClassNative(vm, name);
-    push(vm, OBJ_VAL(klass));
+    ObjModule *module = newModule(vm, name);
+    push(vm, OBJ_VAL(module));
 
     /**
      * Define System methods
      */
-    defineNative(vm, &klass->methods, "strerror", strerrorNative);
-    defineNative(vm, &klass->methods, "getgid", getgidNative);
-    defineNative(vm, &klass->methods, "getegid", getegidNative);
-    defineNative(vm, &klass->methods, "getuid", getuidNative);
-    defineNative(vm, &klass->methods, "geteuid", geteuidNative);
-    defineNative(vm, &klass->methods, "getppid", getppidNative);
-    defineNative(vm, &klass->methods, "getpid", getpidNative);
-    defineNative(vm, &klass->methods, "rmdir", rmdirNative);
-    defineNative(vm, &klass->methods, "mkdir", mkdirNative);
-    defineNative(vm, &klass->methods, "remove", removeNative);
-    defineNative(vm, &klass->methods, "setCWD", setCWDNative);
-    defineNative(vm, &klass->methods, "getCWD", getCWDNative);
-    defineNative(vm, &klass->methods, "time", timeNative);
-    defineNative(vm, &klass->methods, "clock", clockNative);
-    defineNative(vm, &klass->methods, "collect", collectNative);
-    defineNative(vm, &klass->methods, "sleep", sleepNative);
-    defineNative(vm, &klass->methods, "exit", exitNative);
+    defineNative(vm, &module->values, "strerror", strerrorNative);
+    defineNative(vm, &module->values, "getgid", getgidNative);
+    defineNative(vm, &module->values, "getegid", getegidNative);
+    defineNative(vm, &module->values, "getuid", getuidNative);
+    defineNative(vm, &module->values, "geteuid", geteuidNative);
+    defineNative(vm, &module->values, "getppid", getppidNative);
+    defineNative(vm, &module->values, "getpid", getpidNative);
+    defineNative(vm, &module->values, "rmdir", rmdirNative);
+    defineNative(vm, &module->values, "mkdir", mkdirNative);
+    defineNative(vm, &module->values, "remove", removeNative);
+    defineNative(vm, &module->values, "setCWD", setCWDNative);
+    defineNative(vm, &module->values, "getCWD", getCWDNative);
+    defineNative(vm, &module->values, "time", timeNative);
+    defineNative(vm, &module->values, "clock", clockNative);
+    defineNative(vm, &module->values, "collect", collectNative);
+    defineNative(vm, &module->values, "sleep", sleepNative);
+    defineNative(vm, &module->values, "exit", exitNative);
 
     /**
      * Define System properties
      */
     if (!vm->repl) {
         // Set argv variable
-        initArgv(vm, &klass->properties, argc, argv);
+        initArgv(vm, &module->values, argc, argv);
     }
 
-    initPlatform(vm, &klass->properties);
+    initPlatform(vm, &module->values);
 
-    defineNativeProperty(vm, &klass->properties, "errno", NUMBER_VAL(0));
+    defineNativeProperty(vm, &module->values, "errno", NUMBER_VAL(0));
 
-    defineNativeProperty(vm, &klass->properties, "S_IRWXU", NUMBER_VAL(448));
-    defineNativeProperty(vm, &klass->properties, "S_IRUSR", NUMBER_VAL(256));
-    defineNativeProperty(vm, &klass->properties, "S_IWUSR", NUMBER_VAL(128));
-    defineNativeProperty(vm, &klass->properties, "S_IXUSR", NUMBER_VAL(64));
-    defineNativeProperty(vm, &klass->properties, "S_IRWXG", NUMBER_VAL(56));
-    defineNativeProperty(vm, &klass->properties, "S_IRGRP", NUMBER_VAL(32));
-    defineNativeProperty(vm, &klass->properties, "S_IWGRP", NUMBER_VAL(16));
-    defineNativeProperty(vm, &klass->properties, "S_IXGRP", NUMBER_VAL(8));
-    defineNativeProperty(vm, &klass->properties, "S_IRWXO", NUMBER_VAL(7));
-    defineNativeProperty(vm, &klass->properties, "S_IROTH", NUMBER_VAL(4));
-    defineNativeProperty(vm, &klass->properties, "S_IWOTH", NUMBER_VAL(2));
-    defineNativeProperty(vm, &klass->properties, "S_IXOTH", NUMBER_VAL(1));
-    defineNativeProperty(vm, &klass->properties, "S_ISUID", NUMBER_VAL(2048));
-    defineNativeProperty(vm, &klass->properties, "S_ISGID", NUMBER_VAL(1024));
+    defineNativeProperty(vm, &module->values, "S_IRWXU", NUMBER_VAL(448));
+    defineNativeProperty(vm, &module->values, "S_IRUSR", NUMBER_VAL(256));
+    defineNativeProperty(vm, &module->values, "S_IWUSR", NUMBER_VAL(128));
+    defineNativeProperty(vm, &module->values, "S_IXUSR", NUMBER_VAL(64));
+    defineNativeProperty(vm, &module->values, "S_IRWXG", NUMBER_VAL(56));
+    defineNativeProperty(vm, &module->values, "S_IRGRP", NUMBER_VAL(32));
+    defineNativeProperty(vm, &module->values, "S_IWGRP", NUMBER_VAL(16));
+    defineNativeProperty(vm, &module->values, "S_IXGRP", NUMBER_VAL(8));
+    defineNativeProperty(vm, &module->values, "S_IRWXO", NUMBER_VAL(7));
+    defineNativeProperty(vm, &module->values, "S_IROTH", NUMBER_VAL(4));
+    defineNativeProperty(vm, &module->values, "S_IWOTH", NUMBER_VAL(2));
+    defineNativeProperty(vm, &module->values, "S_IXOTH", NUMBER_VAL(1));
+    defineNativeProperty(vm, &module->values, "S_ISUID", NUMBER_VAL(2048));
+    defineNativeProperty(vm, &module->values, "S_ISGID", NUMBER_VAL(1024));
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(klass));
+    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 }

--- a/tests/builtins/type.du
+++ b/tests/builtins/type.du
@@ -31,4 +31,4 @@ with("tests/builtins/type.du", "r") {
     assert(type(file) == "file");
 }
 
-assert(type(System) == "class");
+assert(type(System) == "module");


### PR DESCRIPTION
# Remove "native classes" in favour of modules
## Summary
Currently within the internals of Dictu, there is an object for "native classes" and objects for "modules". "native classes" currently house the Stdlib, for example, `System` or `JSON` for example, and "modules" are used when importing Dictu code, however they both achieve the same effect which is to namespace like code. Both of them are not required so this removes "native classes" in favour of "modules". This will simplify the Dictu internals a lot, and will eventually lead to the ability to import "native classes" rather than having them injected into the VM at runtime.