### PR TITLE
Parameters

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -632,6 +632,7 @@ static void beginFunction(Compiler *compiler, Compiler *fnCompiler, FunctionType
 
         if (fnCompiler->function->arityOptional > 0) {
             emitByte(fnCompiler, OP_DEFINE_OPTIONAL);
+            emitBytes(fnCompiler, fnCompiler->function->arity, fnCompiler->function->arityOptional);
         }
     }
 

--- a/tests/classes/import.du
+++ b/tests/classes/import.du
@@ -13,3 +13,4 @@ import "tests/classes/copy.du";
 import "tests/classes/toString.du";
 import "tests/classes/abstract.du";
 import "tests/classes/classVariables.du";
+import "tests/classes/parameters.du";

--- a/tests/classes/parameters.du
+++ b/tests/classes/parameters.du
@@ -1,0 +1,40 @@
+/**
+ * parameters.du
+ *
+ * Testing the parameters of a method
+ */
+
+class Test {
+    init(a=10, b=20) {
+        this.a = a;
+        this.b = b;
+    }
+}
+
+var obj = Test();
+
+assert(obj.a == 10);
+assert(obj.b == 20);
+
+var obj1 = Test(50);
+
+assert(obj1.a == 50);
+assert(obj1.b == 20);
+
+var obj2 = Test(500, 600);
+
+assert(obj2.a == 500);
+assert(obj2.b == 600);
+
+class AnotherTest {
+    test(a=10, b=20, c=30, d=40, e=50) {
+        return a + b + c + d + e;
+    }
+}
+
+assert(AnotherTest().test() == 150);
+assert(AnotherTest().test(20) == 160);
+assert(AnotherTest().test(20, 30) == 170);
+assert(AnotherTest().test(20, 30, 5) == 145);
+assert(AnotherTest().test(20, 30, 5, 0) == 105);
+assert(AnotherTest().test(20, 30, 5, 0, 1) == 56);


### PR DESCRIPTION
# Parameters
Resolves #243 
## Summary
Currently within the VM, the `DEFINE_OPTIONAL` opcode is basing it's logic on the fact that the thing being called is a closure, which may not always be the case, and may for example be an instance. In that case the default parameters are not working as expected. This PR changes this to instead base it off the function (methods) arg count and arity resolving this issue.