### PR TITLE
Remove some unrequired tables within the VM

### DIFF
--- a/c/memory.c
+++ b/c/memory.c
@@ -282,8 +282,6 @@ void collectGarbage(VM *vm) {
     // Mark the global roots.
     grayTable(vm, &vm->modules);
     grayTable(vm, &vm->globals);
-    grayTable(vm, &vm->constants);
-    grayTable(vm, &vm->imports);
     grayTable(vm, &vm->numberMethods);
     grayTable(vm, &vm->boolMethods);
     grayTable(vm, &vm->nilMethods);

--- a/c/value.h
+++ b/c/value.h
@@ -26,7 +26,7 @@ typedef struct sObjFile ObjFile;
 
 typedef uint64_t Value;
 
-#define IS_BOOL(v)    (((v) & FALSE_VAL) == FALSE_VAL)
+#define IS_BOOL(v)    (((v) | 1) == TRUE_VAL)
 #define IS_NIL(v)     ((v) == NIL_VAL)
 #define IS_EMPTY(v)   ((v) == EMPTY_VAL)
 // If the NaN bits are set, it's not a number.

--- a/c/vm.c
+++ b/c/vm.c
@@ -104,7 +104,6 @@ VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
     initTable(&vm->globals);
     initTable(&vm->constants);
     initTable(&vm->strings);
-    initTable(&vm->imports);
 
     initTable(&vm->numberMethods);
     initTable(&vm->boolMethods);
@@ -159,7 +158,6 @@ void freeVM(VM *vm) {
     freeTable(vm, &vm->globals);
     freeTable(vm, &vm->constants);
     freeTable(vm, &vm->strings);
-    freeTable(vm, &vm->imports);
     freeTable(vm, &vm->numberMethods);
     freeTable(vm, &vm->boolMethods);
     freeTable(vm, &vm->nilMethods);

--- a/c/vm.h
+++ b/c/vm.h
@@ -31,7 +31,6 @@ struct _vm {
     Table globals;
     Table constants;
     Table strings;
-    Table imports;
     Table numberMethods;
     Table boolMethods;
     Table nilMethods;


### PR DESCRIPTION
# Cleanup
## Summary
This PR does a couple of small cleanup tasks. Firstly it removes `constants` from the table being greyed as part of the GC procedure as this will be covered by the globals table. It then removes the `imports` table as this is no longer used now that modules have been implemented. Lastly it changes the `IS_BOOL` macro.