### PR TITLE
Remove quotes around string when converting string object to cstring

### DIFF
--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -617,8 +617,9 @@ char *objectToString(Value value) {
 
         case OBJ_STRING: {
             ObjString *stringObj = AS_STRING(value);
-            char *string = malloc(sizeof(char) * stringObj->length + 3);
-            snprintf(string, stringObj->length + 3, "'%s'", stringObj->chars);
+            char *string = malloc(sizeof(char) * stringObj->length + 1);
+            memcpy(string, stringObj->chars, stringObj->length);
+            string[stringObj->length] = '\0';
             return string;
         }
 


### PR DESCRIPTION
# String
## Summary
This removes the quotes around the string when converting a string object to a c-string, for example when printing a string object. The rationale for this is we are using Dictu within AWS and it needs to correctly print out valid JSON, these single quotes are interfering. The other reason is that there isn't really a need for them to be there, if a user wants strings to be there they can define that within the language when printing e.g `print("'string'");` rather than have it forced upon them.