### PR TITLE
Class inheritance

### DIFF
--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -1697,13 +1697,12 @@ static void classDeclaration(Compiler *compiler) {
     setupClassCompiler(compiler, &classCompiler, false);
 
     if (match(compiler, TOKEN_LESS)) {
-        consume(compiler, TOKEN_IDENTIFIER, "Expect superclass name.");
+        expression(compiler);
         classCompiler.hasSuperclass = true;
 
         beginScope(compiler);
 
         // Store the superclass in a local variable named "super".
-        variable(compiler, false);
         addLocal(compiler, syntheticToken("super"));
 
         emitBytes(compiler, OP_SUBCLASS, CLASS_DEFAULT);
@@ -1730,9 +1729,9 @@ static void classDeclaration(Compiler *compiler) {
 }
 
 static void abstractClassDeclaration(Compiler *compiler) {
-    consume(compiler, TOKEN_CLASS, "Expect class keyword.");
+    consume(compiler, TOKEN_CLASS, "Expect class keyword after abstract.");
 
-    consume(compiler, TOKEN_IDENTIFIER, "Expect class name.");
+    consume(compiler, TOKEN_IDENTIFIER, "Expect class name after class keyword.");
     uint8_t nameConstant = identifierConstant(compiler, &compiler->parser->previous);
     declareVariable(compiler, &compiler->parser->previous);
 
@@ -1740,13 +1739,12 @@ static void abstractClassDeclaration(Compiler *compiler) {
     setupClassCompiler(compiler, &classCompiler, true);
 
     if (match(compiler, TOKEN_LESS)) {
-        consume(compiler, TOKEN_IDENTIFIER, "Expect superclass name.");
+        expression(compiler);
         classCompiler.hasSuperclass = true;
 
         beginScope(compiler);
 
         // Store the superclass in a local variable named "super".
-        variable(compiler, false);
         addLocal(compiler, syntheticToken("super"));
 
         emitBytes(compiler, OP_SUBCLASS, CLASS_ABSTRACT);

--- a/tests/classes/inherit.du
+++ b/tests/classes/inherit.du
@@ -26,3 +26,15 @@ class Testing < Base {
 assert(Test().func() == 10);
 assert(Testing().value == 10);
 assert(Testing().newFunc() == 10);
+
+// Test inheritance works via an expression.
+const dict = {"class": Testing};
+
+class AnotherTest < dict["class"] {
+    init() {
+        super.init();
+    }
+}
+
+assert(AnotherTest().value == 10);
+assert(AnotherTest().newFunc() == 10);


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

This change makes it so that the superclass can be denoted by an expression rather than a single identifier. This means we can store classes within different datatypes (such as a dictionary) and use this as the value for the superclass

Example:
```
class Test {}

const dict = {"class": Test};

class Inherit < dict["class"] {}
```


This will mainly be useful when modules within the stdlib start getting built in classes, it means we don't need to fully import the class into the namespace and instead can reference through the module namespace

Example
```
import UnitTest;

class Test < UnitTest.UnitTest {
    // Tests here
}
```

<!-- Link the issue below if you are resolving an issue !-->

Resolves: 
 
#472 

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [x] New feature

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [x] Tests have been updated to reflect the changes done within this PR (if applicable).

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).
