### PR TITLE
Pop switch expression  correctly

### DIFF
--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -2350,8 +2350,8 @@ static void switchStatement(Compiler *compiler) {
 
     } while(match(compiler, TOKEN_CASE));
 
+    emitByte(compiler, OP_POP); // expression.
     if (match(compiler,TOKEN_DEFAULT)){
-        emitByte(compiler, OP_POP); // expression.
         consume(compiler, TOKEN_COLON, "Expect ':' after default.");
         statement(compiler);
     }


### PR DESCRIPTION
This PR fixes a small behaviour bug with the switch statement. Prior to this, the switch expression was never popped out of stack at the end of the case statements, polluting the stack and leading to problems.

### Type of change:

- [X] Bug fix
